### PR TITLE
add schema inputs for Actions

### DIFF
--- a/docs/_includes/docs/core/actions.html
+++ b/docs/_includes/docs/core/actions.html
@@ -181,6 +181,24 @@ action.inputs = {
     default:   function(param, connection, actionTemplate){
       return 1;
     },
+  },
+  // a schema input
+  schemaInput: {
+    required: true,
+    default: {},
+    schema: {
+      nestedInput: {
+        required: true,
+        default: 1,
+        validator: function(param, connection, actionTemplate){
+          if(param < 0){ return 'must be > 0'; }else{ return true; }
+        },
+        formatter: function(param, connection, actionTemplate){
+          return parseInt(param);
+        },
+      },
+      otherInput: {},
+    }
   }
 };
   {% endhighlight %}
@@ -214,6 +232,14 @@ action.inputs = {
         <li>should return <code>true</code> if validation passed</li>
         <li>should return an error message if validation fails which will be returned to the client</li>
         <li>Default: Parameter is always valid</li>
+      </ul>
+    </li>
+    <li>
+      <code>schema</code> (object)
+      <ul>
+        <li>optional nested inputs definition</li>
+        <li>accept <code>object</code> similar to regular input</li>
+        <li>nested input also have properties: <code>required</code>, <code>formatter</code>, <code>default</code> and <code>validator</code></li>
       </ul>
     </li>
   </ul>
@@ -305,7 +331,35 @@ module.exports = {
   },
 };
   {% endhighlight %}
+  
+  <p>Example schema input:</p>
 
+  {% highlight javascript %}
+  exports.addUser = {
+    name: 'api/addUser',
+    description: 'I add user',
+    
+    firstName: { required: true },
+    lastName: { required: false },
+    username: { required: true },
+    address: {
+      required: false,
+      schema: {
+        country: {
+          required: true,
+          default: 'USA'
+        },
+        state: { required: false },
+        city: {
+          required: true,
+          formatter: (val) => `City:${val}`,
+          validator: (val) => val.length > 10,
+        }
+      }
+    }
+    run: () => {},
+  }
+  {% endhighlight %}
 
   <h2 id="actions-the-data-object">The Data Object</h2>
 

--- a/initializers/actionProcessor.js
+++ b/initializers/actionProcessor.js
@@ -169,71 +169,96 @@ module.exports = {
       async.series(processors, callback)
     }
 
-    api.ActionProcessor.prototype.reduceParams = function () {
-      let inputNames = []
-      if (this.actionTemplate.inputs) {
-        inputNames = Object.keys(this.actionTemplate.inputs)
+    api.ActionProcessor.prototype.reduceParams = function (schemaKey) {
+      let inputs = this.actionTemplate.inputs || {}
+      let params = this.params
+      if (schemaKey) {
+        inputs = this.actionTemplate.inputs[schemaKey].schema
+        params = this.params[schemaKey]
       }
 
+      const inputNames = Object.keys(inputs) || []
       if (api.config.general.disableParamScrubbing !== true) {
-        for (let p in this.params) {
+        for (let p in params) {
           if (api.params.globalSafeParams.indexOf(p) < 0 && inputNames.indexOf(p) < 0) {
-            delete this.params[p]
+            delete params[p]
           }
         }
       }
     }
 
-    api.ActionProcessor.prototype.validateParams = function () {
-      for (let key in this.actionTemplate.inputs) {
-        const props = this.actionTemplate.inputs[key]
-
-        // default
-        if (this.params[key] === undefined && props['default'] !== undefined) {
-          if (typeof props['default'] === 'function') {
-            this.params[key] = props['default'].call(api, this.params[key], this)
-          } else {
-            this.params[key] = props['default']
-          }
-        }
-
-        // formatter
-        if (this.params[key] !== undefined && props.formatter !== undefined) {
-          if (!Array.isArray(props.formatter)) { props.formatter = [props.formatter] }
-
-          props.formatter.forEach((formatter) => {
-            if (typeof formatter === 'function') {
-              this.params[key] = formatter.call(api, this.params[key], this)
-            } else {
-              const method = prepareStringMethod(formatter)
-              this.params[key] = method.call(api, this.params[key], this)
-            }
-          })
-        }
-
-        // validator
-        if (this.params[key] !== undefined && props.validator !== undefined) {
-          if (!Array.isArray(props.validator)) { props.validator = [props.validator] }
-
-          props.validator.forEach((validator) => {
-            let validatorResponse
-            if (typeof validator === 'function') {
-              validatorResponse = validator.call(api, this.params[key], this)
-            } else {
-              const method = prepareStringMethod(validator)
-              validatorResponse = method.call(api, this.params[key], this)
-            }
-            if (validatorResponse !== true) { this.validatorErrors.push(validatorResponse) }
-          })
-        }
-
-        // required
-        if (props.required === true) {
-          if (api.config.general.missingParamChecks.indexOf(this.params[key]) >= 0) {
-            this.missingParams.push(key)
-          }
+    api.ActionProcessor.prototype.validateParam = function (props, param, key, schemaKey) {
+      let result = param
+      // default
+      if (result === undefined && props['default'] !== undefined) {
+        if (typeof props['default'] === 'function') {
+          result = props['default'].call(api, result, this)
+        } else {
+          result = props['default']
         }
       }
+
+      // formatter
+      if (result !== undefined && props.formatter !== undefined) {
+        if (!Array.isArray(props.formatter)) { props.formatter = [props.formatter] }
+
+        props.formatter.forEach((formatter) => {
+          if (typeof formatter === 'function') {
+            result = formatter.call(api, result, this)
+          } else {
+            const method = prepareStringMethod(formatter)
+            result = method.call(api, result, this)
+          }
+        })
+      }
+
+      // validator
+      if (result !== undefined && props.validator !== undefined) {
+        if (!Array.isArray(props.validator)) { props.validator = [props.validator] }
+
+        props.validator.forEach((validator) => {
+          let validatorResponse
+          if (typeof validator === 'function') {
+            validatorResponse = validator.call(api, result, this)
+          } else {
+            const method = prepareStringMethod(validator)
+            validatorResponse = method.call(api, result, this)
+          }
+          if (validatorResponse !== true) { this.validatorErrors.push(validatorResponse) }
+        })
+      }
+
+      // required
+      if (props.required === true) {
+        if (api.config.general.missingParamChecks.indexOf(result) >= 0) {
+          let missingKey = key
+          if (schemaKey) {
+            missingKey = `${schemaKey}.${missingKey}`
+          }
+          this.missingParams.push(missingKey)
+        }
+      }
+
+      return result
+    }
+
+    api.ActionProcessor.prototype.validateParams = function (schemaKey) {
+      let inputs = this.actionTemplate.inputs || {}
+      let params = this.params
+      if (schemaKey) {
+        inputs = this.actionTemplate.inputs[schemaKey].schema
+        params = this.params[schemaKey]
+      }
+
+      Object.keys(inputs).forEach((key) => {
+        const props = inputs[key]
+        params[key] = this.validateParam(props, params[key], key, schemaKey)
+
+        if (props.schema && params[key]) {
+          this.reduceParams(key)
+          this.validateParams(key)
+        }
+      })
     }
 
     api.ActionProcessor.prototype.processAction = function () {

--- a/test/core/api.js
+++ b/test/core/api.js
@@ -316,9 +316,9 @@ describe('Core: API', () => {
 
     it('will fail for missing or empty string params', (done) => {
       api.specHelper.runAction('testAction', {schemaParam: {requiredParam: ''}}, (response) => {
-        expect(response.error).to.contain('required parameter for this action')
+        expect(response.error).to.contain('schemaParam.requiredParam is a required parameter for this action')
         api.specHelper.runAction('testAction', {schemaParam: {}}, (response) => {
-          expect(response.error).to.match(/requiredParam is a required parameter for this action/)
+          expect(response.error).to.contain('schemaParam.requiredParam is a required parameter for this action')
           done()
         })
       })


### PR DESCRIPTION
Add schema input type for actions:
```
inputs: {
  userData: {
    required: false,
    schema: {
      id: {
        required: false,
        validator: validator('isInt', 'id validate error'),
      },
      name: {
        required: false,
        validator: validator('isLength', 'name validate error'),
      },
    },
  },
},
```

- [x] add tests
- [x] run `npm test`