### PR TITLE
Fix cache lock

### DIFF
--- a/initializers/cache.js
+++ b/initializers/cache.js
@@ -256,7 +256,7 @@ module.exports = {
               return callback(error)
             } else {
               if (!result) { // value was already set, so we cannot obtain the lock
-                return callback(null, false);
+                return callback(null, false)
               }
               redis.expire(api.cache.lockPrefix + key, Math.ceil(expireTimeMS / 1000), (error) => {
                 lockOk = true

--- a/initializers/cache.js
+++ b/initializers/cache.js
@@ -251,10 +251,13 @@ module.exports = {
         if (error || lockOk !== true) {
           return callback(error, false)
         } else {
-          redis.setnx(api.cache.lockPrefix + key, api.cache.lockName, (error) => {
+          redis.setnx(api.cache.lockPrefix + key, api.cache.lockName, (error, result) => {
             if (error) {
               return callback(error)
             } else {
+              if (!result) { // value was already set, so we cannot obtain the lock
+                return callback(null, false);
+              }
               redis.expire(api.cache.lockPrefix + key, Math.ceil(expireTimeMS / 1000), (error) => {
                 lockOk = true
                 if (error) { lockOk = false }


### PR DESCRIPTION
The current implementation of the `cache.lock` method does not check the result of the `setnx` function, which returns either 1 if the key didn't previous exist, and 0 otherwise, this can lead to multiple nodes aquiring the same lock multiple times. 