### PR TITLE
Saner localization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ log/*
 cache/*
 coverage/*
 node_modules/*
-locales/*
 public/javascript/actionheroClient.js
 public/javascript/actionheroClient.min.js
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ log/*
 cache/*
 coverage/*
 node_modules/*
+locales/test-env-*
 public/javascript/actionheroClient.js
 public/javascript/actionheroClient.min.js
 

--- a/actionhero.js
+++ b/actionhero.js
@@ -251,6 +251,8 @@ actionhero.prototype.start = function (params, callback) {
   const _start = () => {
     this.api.running = true
 
+    this.api.log('*** Starting ActionHero ***', 'notice')
+
     this.startInitializers.push(() => {
       this.api.bootTime = new Date().getTime()
       if (startCount === 0) {

--- a/actionhero.js
+++ b/actionhero.js
@@ -14,7 +14,7 @@ const fatalError = function (api, errors, type) {
   if (errors && !(errors instanceof Array)) { errors = [errors] }
   if (errors) {
     if (api.log) {
-      api.log(['Error with initializer step: %s', type], 'emerg')
+      api.log(`Error with initializer step: ${type}`, 'emerg')
       errors.forEach((error) => { api.log(error.stack, 'emerg') })
     } else {
       console.error('Error with initializer step: ' + type)
@@ -145,14 +145,14 @@ actionhero.prototype.initialize = function (params, callback) {
 
         const loadFunction = (next) => {
           this.api.watchFileAndAct(file, () => {
-            this.api.log(['*** Rebooting due to initializer change (%s) ***', file], 'info')
+            this.api.log(`*** Rebooting due to initializer change (${file}) ***`, 'info')
             this.api.commands.restart()
           })
 
           if (typeof this.initializers[initializer].initialize === 'function') {
-            if (typeof this.api.log === 'function') { this.api.log(['Loading initializer: %s', initializer], 'debug', file) }
+            if (typeof this.api.log === 'function') { this.api.log(`Loading initializer: ${initializer}`, 'debug', file) }
             this.initializers[initializer].initialize(this.api, (error) => {
-              try { this.api.log(['Loaded initializer: %s', initializer], 'debug', file) } catch (e) { }
+              try { this.api.log(`Loaded initializer: ${initializer}`, 'debug', file) } catch (e) { }
               next(error)
             })
           } else {
@@ -162,9 +162,9 @@ actionhero.prototype.initialize = function (params, callback) {
 
         const startFunction = (next) => {
           if (typeof this.initializers[initializer].start === 'function') {
-            if (typeof this.api.log === 'function') { this.api.log(['Starting initializer: %s', initializer], 'debug', file) }
+            if (typeof this.api.log === 'function') { this.api.log(`Starting initializer: ${initializer}`, 'debug', file) }
             this.initializers[initializer].start(this.api, (error) => {
-              this.api.log(['Started initializer: %s', initializer], 'debug', file)
+              this.api.log(`Started initializer: ${initializer}`, 'debug', file)
               next(error)
             })
           } else {
@@ -174,9 +174,9 @@ actionhero.prototype.initialize = function (params, callback) {
 
         const stopFunction = (next) => {
           if (typeof this.initializers[initializer].stop === 'function') {
-            if (typeof this.api.log === 'function') { this.api.log(['Stopping initializer: %s', initializer], 'debug', file) }
+            if (typeof this.api.log === 'function') { this.api.log(`Stopping initializer: ${initializer}`, 'debug', file) }
             this.initializers[initializer].stop(this.api, (error) => {
-              this.api.log(['Stopped initializer: %s', initializer], 'debug', file)
+              this.api.log(`Stopped initializer: ${initializer}`, 'debug', file)
               next(error)
             })
           } else {
@@ -228,7 +228,7 @@ actionhero.prototype.initialize = function (params, callback) {
         this.api.initialized = true
 
         if (duplicatedInitializers.length > 0) {
-          duplicatedInitializers.forEach(initializer => this.api.log(['Initializer %s already exists!', initializer], 'error'))
+          duplicatedInitializers.forEach(initializer => this.api.log(`Initializer ${initializer} already exists!`, 'error'))
           this.api.commands.stop.call(this.api, () => {
             process.exit(1)
           })
@@ -254,9 +254,9 @@ actionhero.prototype.start = function (params, callback) {
     this.startInitializers.push(() => {
       this.api.bootTime = new Date().getTime()
       if (startCount === 0) {
-        this.api.log(['*** ActionHero Started ***'], 'alert')
+        this.api.log('*** ActionHero Started ***', 'alert')
       } else {
-        this.api.log(['*** ActionHero Restarted ***'], 'alert')
+        this.api.log('*** ActionHero Restarted ***', 'alert')
       }
 
       startCount++

--- a/actions/randomNumber.js
+++ b/actions/randomNumber.js
@@ -9,7 +9,7 @@ exports.randomNumber = {
 
   run: function (api, data, next) {
     data.response.randomNumber = Math.random()
-    data.response.stringRandomNumber = data.connection.localize(['Your random number is %s', Math.random()])
+    data.response.stringRandomNumber = data.connection.localize(['Your random number is {{number}}', {number: Math.random()}])
     next(null)
   }
 

--- a/actions/status.js
+++ b/actions/status.js
@@ -26,7 +26,7 @@ exports.status = {
       data.response.consumedMemoryMB = consumedMemoryMB
       if (consumedMemoryMB > maxMemoryAlloted) {
         data.response.nodeStatus = data.connection.localize('Unhealthy')
-        data.response.problems.push(data.connection.localize('Using more than ' + maxMemoryAlloted + 'MB of RAM/HEAP'))
+        data.response.problems.push(data.connection.localize(['Using more than {{maxMemoryAlloted}} MB of RAM/HEAP', {maxMemoryAlloted: maxMemoryAlloted}]))
       }
 
       callback()
@@ -38,7 +38,7 @@ exports.status = {
         data.response.eventLoopDelay = eventLoopDelay
         if (eventLoopDelay > maxEventLoopDelay) {
           data.response.nodeStatus = data.connection.localize('Node Unhealthy')
-          data.response.problems.push(data.connection.localize('EventLoop Blocked for more than ' + maxEventLoopDelay + 'ms'))
+          data.response.problems.push(data.connection.localize(['EventLoop Blocked for more than {{maxEventLoopDelay}} ms', {maxEventLoopDelay: maxEventLoopDelay}]))
         }
 
         callback()
@@ -57,7 +57,7 @@ exports.status = {
 
         if (length > maxResqueQueueLength) {
           data.response.nodeStatus = data.connection.localize('Node Unhealthy')
-          data.response.problems.push(data.connection.localize('Resque Queues over ' + maxResqueQueueLength + ' jobs'))
+          data.response.problems.push(data.connection.localize(['Resque Queues over {{maxResqueQueueLength}} jobs', {maxResqueQueueLength: maxResqueQueueLength}]))
         }
 
         callback()

--- a/bin/actionhero
+++ b/bin/actionhero
@@ -41,9 +41,9 @@ if (commands.length === 1 && ['generate', 'help', 'version'].indexOf(commands[0]
       const runner = require(path.join(__dirname, 'methods', commands.join(path.sep) + '.js'))
 
       api.log('--------------------------------------')
-      api.log(['ACTIONHERO COMMAND >> %s', commands.join(' ')])
-      api.log(['projectRoot: %s', path.normalize(projectRoot)], 'debug')
-      api.log(['actionheroRoot: %s', path.normalize(actionheroRoot)], 'debug')
+      api.log(`ACTIONHERO COMMAND >> ${commands.join(' ')}`)
+      api.log(`projectRoot: ${path.normalize(projectRoot)}`, 'debug')
+      api.log(`actionheroRoot: ${path.normalize(actionheroRoot)}`, 'debug')
       api.log('--------------------------------------')
 
       if (optimist.argv.daemon) {
@@ -54,8 +54,8 @@ if (commands.length === 1 && ['generate', 'help', 'version'].indexOf(commands[0]
         newArgs.push('--isDaemon=true')
         const command = path.normalize(actionheroRoot + '/bin/actionhero')
         const child = spawn(command, newArgs, {detached: true, cwd: process.cwd(), env: process.env, stdio: 'ignore'})
-        api.log(['%s %s', command, newArgs.join(' ')], 'debug')
-        api.log(['spawned child process with pid %s', child.pid], 'notice')
+        api.log(`${command} ${newArgs.join(' ')}`, 'debug')
+        api.log(`spawned child process with pid ${child.pid}`, 'notice')
         process.nextTick(process.exit)
       } else {
         runner(api, function (error, toStop) {
@@ -67,7 +67,7 @@ if (commands.length === 1 && ['generate', 'help', 'version'].indexOf(commands[0]
       if (!e.message.match(/Cannot find module/)) {
         throw (e)
       } else {
-        api.log(['Error: `%s` is not a method I can perform', commands.join(' ')], 'error')
+        api.log(`Error: \`${commands.join(' ')}\` is not a method I can perform`, 'error')
         api.log('run `actionhero help` to learn more', 'error')
         setTimeout(process.exit, 500, 1)
       }

--- a/bin/methods/actions/list.js
+++ b/bin/methods/actions/list.js
@@ -2,16 +2,16 @@
 
 module.exports = function (api, next) {
   for (let actionName in api.actions.actions) {
-    api.log(['%s', actionName])
+    api.log(actionName)
     let collection = api.actions.actions[actionName]
 
     for (let version in collection) {
       let action = collection[version]
-      api.log(['  version: %s', version])
-      api.log(['    %s', action.description])
-      api.log(['    inputs: '])
+      api.log(`  version: ${version}`)
+      api.log(`    ${action.description}`)
+      api.log(`    inputs:`)
       for (let input in action.inputs) {
-        api.log(['      %s: %s', input, JSON.stringify(action.inputs[input])])
+        api.log(`      ${input}: ${JSON.stringify(action.inputs[input])}`)
       }
     }
   }

--- a/bin/methods/generate.js
+++ b/bin/methods/generate.js
@@ -38,7 +38,7 @@ module.exports = function (api, next) {
       publicChat: '/public/chat.html',
       publicLogo: '/public/logo/actionhero.png',
       publicCss: '/public/css/cosmo.css',
-      exampleTest: '/test/template.js.example'
+      exampleTest: '/test/template.js.example',
       enLocale: '/locales/en.json'
     }
 
@@ -97,7 +97,7 @@ module.exports = function (api, next) {
       '/public/css/cosmo.css': 'publicCss',
       '/public/logo/actionhero.png': 'publicLogo',
       '/README.md': 'readmeMd',
-      '/test/example.js': 'exampleTest'
+      '/test/example.js': 'exampleTest',
       '/locales/en.json': 'enLocale'
     }
 

--- a/bin/methods/generate.js
+++ b/bin/methods/generate.js
@@ -39,6 +39,7 @@ module.exports = function (api, next) {
       publicLogo: '/public/logo/actionhero.png',
       publicCss: '/public/css/cosmo.css',
       exampleTest: '/test/template.js.example'
+      enLocale: '/locales/en.json'
     }
 
     for (let name in oldFileMap) {
@@ -63,6 +64,7 @@ module.exports = function (api, next) {
       '/config/servers',
       '/initializers',
       '/log',
+      '/locales',
       '/servers',
       '/public',
       '/public/javascript',
@@ -96,6 +98,7 @@ module.exports = function (api, next) {
       '/public/logo/actionhero.png': 'publicLogo',
       '/README.md': 'readmeMd',
       '/test/example.js': 'exampleTest'
+      '/locales/en.json': 'enLocale'
     }
 
     for (let file in newFileMap) {

--- a/bin/methods/link.js
+++ b/bin/methods/link.js
@@ -24,12 +24,12 @@ module.exports = function (api, next) {
   })
 
   if (!pluginRoot) {
-    api.log(['plugin `%s` not found in plugin paths', argv.name], 'warning', api.config.general.paths.plugin)
+    api.log(`plugin \`${argv.name}\` not found in plugin paths`, 'warning', api.config.general.paths.plugin)
     return next(null, true)
   }
 
   let pluginRootRelative = pluginRoot.replace(linkRelativeBase, '')
-  api.log(['linking the plugin found at %s', pluginRootRelative]);
+  api.log(`linking the plugin found at ${pluginRootRelative}`);
 
   // link actionable files
   [

--- a/bin/methods/start.js
+++ b/bin/methods/start.js
@@ -18,7 +18,7 @@ module.exports = function (api, next) {
     if (cluster.isWorker) { process.send({state: state}) }
     api._context.start(function (error, apiFromCallback) {
       if (error) {
-        api.log(['%s', error])
+        api.log(error)
         process.exit(1)
       } else {
         state = 'started'

--- a/bin/methods/task/enqueue.js
+++ b/bin/methods/task/enqueue.js
@@ -16,7 +16,7 @@ module.exports = function (api, next) {
   api.resque.startQueue(function () {
     api.tasks.enqueue(argv.name, args, function (error, toRun) {
       if (error) {
-        api.log(['%s', error], 'alert')
+        api.log(error, 'alert')
       } else {
         api.log('response', 'info', toRun)
       }

--- a/bin/methods/unlink.js
+++ b/bin/methods/unlink.js
@@ -20,12 +20,12 @@ module.exports = function (api, next) {
   })
 
   if (!pluginRoot) {
-    api.log(['plugin `%s` not found in plugin paths', argv.name], 'warning', api.config.general.paths.plugin)
+    api.log(`plugin \`${argv.name}\` not found in plugin paths`, 'warning', api.config.general.paths.plugin)
     return next(null, true)
   }
 
   const pluginRootRelative = pluginRoot.replace(linkRelativeBase, '')
-  api.log(['unlinking the plugin found at %s', pluginRootRelative]);
+  api.log(`unlinking the plugin found at ${pluginRootRelative}`);
 
   // unlink actionable files
   [

--- a/config/api.js
+++ b/config/api.js
@@ -74,7 +74,10 @@ exports.test = {
         'otherRoom': {}
       },
       paths: {
-        'locale': [require('os').tmpdir() + require('path').sep + 'locales']
+        'locale': [
+          // require('os').tmpdir() + require('path').sep + 'locales',
+          path.join(__dirname, '/../locales')
+        ]
       },
       rpcTimeout: 3000
     }

--- a/config/api.js
+++ b/config/api.js
@@ -14,8 +14,6 @@ exports['default'] = {
       //  id: 'myActionHeroServer',
       // A unique token to your application that servers will use to authenticate to each other
       serverToken: 'change-me',
-      // The welcome message seen by TCP and webSocket clients upon connection
-      welcomeMessage: 'Hello! Welcome to the actionhero api',
       // the redis prefix for actionhero's cache objects
       cachePrefix: 'actionhero:cache:',
       // the redis prefix for actionhero's cache/lock objects

--- a/config/errors.js
+++ b/config/errors.js
@@ -50,37 +50,37 @@ exports['default'] = {
       // When a params for an action is invalid
       invalidParams: function (data, validationErrors) {
         if (validationErrors.length >= 0) { return validationErrors[0] }
-        return 'validation error'
+        return data.connection.localize('actionhero.errors.invalidParams')
       },
 
       // When a required param for an action is not provided
       missingParams: function (data, missingParams) {
-        return data.connection.localize(['{{param}} is a required parameter for this action', {param: missingParams[0]}])
+        return data.connection.localize(['actionhero.errors.missingParams', {param: missingParams[0]}])
       },
 
       // user requested an unknown action
       unknownAction: function (data) {
-        return data.connection.localize('unknown action or invalid apiVersion')
+        return data.connection.localize('actionhero.errors.unknownActionAction')
       },
 
       // action not useable by this client/server type
       unsupportedServerType: function (data) {
-        return data.connection.localize(['this action does not support the {{type}} connection type', {type: data.connection.type}])
+        return data.connection.localize(['actionhero.errors.unsupportedServerType', {type: data.connection.type}])
       },
 
       // action failed because server is mid-shutdown
       serverShuttingDown: function (data) {
-        return data.connection.localize('the server is shutting down')
+        return data.connection.localize('actionhero.errors.serverShuttingDown')
       },
 
       // action failed because this client already has too many pending acitons
       // limit defined in api.config.general.simultaneousActions
       tooManyPendingActions: function (data) {
-        return data.connection.localize('you have too many pending requests')
+        return data.connection.localize('actionhero.errors.tooManyPendingActions')
       },
 
       dataLengthTooLarge: function (maxLength, receivedLength) {
-        return api.i18n.localize(['data length is too big ({{maxLength}} received/{{receivedLength}} max)', {maxLength: maxLength, receivedLength: receivedLength}])
+        return api.i18n.localize(['actionhero.errors.dataLengthTooLarge', {maxLength: maxLength, receivedLength: receivedLength}])
       },
 
       // ///////////////
@@ -90,17 +90,17 @@ exports['default'] = {
       // The body message to accompany 404 (file not found) errors regarding flat files
       // You may want to load in the contnet of 404.html or similar
       fileNotFound: function (connection) {
-        return connection.localize(['That file is not found'])
+        return connection.localize(['actionhero.errors.fileNotFound'])
       },
 
       // user didn't request a file
       fileNotProvided: function (connection) {
-        return connection.localize('file is a required param to send a file')
+        return connection.localize('actionhero.errors.fileNotProvided')
       },
 
       // something went wrong trying to read the file
       fileReadError: function (connection, error) {
-        return connection.localize(['error reading file: {{error}}', {error: String(error)}])
+        return connection.localize(['actionhero.errors.fileReadError', {error: String(error)}])
       },
 
       // ///////////////
@@ -108,39 +108,39 @@ exports['default'] = {
       // ///////////////
 
       verbNotFound: function (connection, verb) {
-        return connection.localize(['I do not know know to perform this verb ({{verb}})', {verb: verb}])
+        return connection.localize(['actionhero.errors.verbNotFound', {verb: verb}])
       },
 
       verbNotAllowed: function (connection, verb) {
-        return connection.localize(['verb not found or not allowed ({{verb}})', {verb: verb}])
+        return connection.localize(['actionhero.errors.verbNotAllowed', {verb: verb}])
       },
 
       connectionRoomAndMessage: function (connection) {
-        return connection.localize('both room and message are required')
+        return connection.localize('actionhero.errors.connectionRoomAndMessage')
       },
 
       connectionNotInRoom: function (connection, room) {
-        return connection.localize(['connection not in this room ({{room}})', {room: room}])
+        return connection.localize(['actionhero.errors.connectionNotInRoom', {room: room}])
       },
 
       connectionAlreadyInRoom: function (connection, room) {
-        return connection.localize(['connection already in this room ({{room}})', {room: room}])
+        return connection.localize(['actionhero.errors.connectionAlreadyInRoom', {room: room}])
       },
 
       connectionRoomHasBeenDeleted: function (room) {
-        return api.i18n.localize('this room has been deleted')
+        return api.i18n.localize('actionhero.errors.connectionRoomHasBeenDeleted')
       },
 
       connectionRoomNotExist: function (room) {
-        return api.i18n.localize('room does not exist')
+        return api.i18n.localize('actionhero.errors.connectionRoomNotExist')
       },
 
       connectionRoomExists: function (room) {
-        return api.i18n.localize('room exists')
+        return api.i18n.localize('actionhero.errors.connectionRoomExists')
       },
 
       connectionRoomRequired: function (room) {
-        return api.i18n.localize('a room is required')
+        return api.i18n.localize('actionhero.errors.connectionRoomRequired')
       }
 
     }

--- a/config/errors.js
+++ b/config/errors.js
@@ -55,7 +55,7 @@ exports['default'] = {
 
       // When a required param for an action is not provided
       missingParams: function (data, missingParams) {
-        return data.connection.localize(['%s is a required parameter for this action', missingParams[0]])
+        return data.connection.localize(['{{param}} is a required parameter for this action', {param: missingParams[0]}])
       },
 
       // user requested an unknown action
@@ -65,7 +65,7 @@ exports['default'] = {
 
       // action not useable by this client/server type
       unsupportedServerType: function (data) {
-        return data.connection.localize(['this action does not support the %s connection type', data.connection.type])
+        return data.connection.localize(['this action does not support the {{type}} connection type', {type: data.connection.type}])
       },
 
       // action failed because server is mid-shutdown
@@ -80,7 +80,7 @@ exports['default'] = {
       },
 
       dataLengthTooLarge: function (maxLength, receivedLength) {
-        return api.i18n.localize(['data length is too big (%u received/%u max)', maxLength, receivedLength])
+        return api.i18n.localize(['data length is too big ({{maxLength}} received/{{receivedLength}} max)', {maxLength: maxLength, receivedLength: receivedLength}])
       },
 
       // ///////////////
@@ -100,7 +100,7 @@ exports['default'] = {
 
       // something went wrong trying to read the file
       fileReadError: function (connection, error) {
-        return connection.localize(['error reading file: %s', String(error)])
+        return connection.localize(['error reading file: {{error}}', {error: String(error)}])
       },
 
       // ///////////////
@@ -108,11 +108,11 @@ exports['default'] = {
       // ///////////////
 
       verbNotFound: function (connection, verb) {
-        return connection.localize(['I do not know know to perform this verb (%s)', verb])
+        return connection.localize(['I do not know know to perform this verb ({{verb}})', {verb: verb}])
       },
 
       verbNotAllowed: function (connection, verb) {
-        return connection.localize(['verb not found or not allowed (%s)', verb])
+        return connection.localize(['verb not found or not allowed ({{verb}})', {verb: verb}])
       },
 
       connectionRoomAndMessage: function (connection) {
@@ -120,11 +120,11 @@ exports['default'] = {
       },
 
       connectionNotInRoom: function (connection, room) {
-        return connection.localize(['connection not in this room (%s)', room])
+        return connection.localize(['connection not in this room ({{room}})', {room: room}])
       },
 
       connectionAlreadyInRoom: function (connection, room) {
-        return connection.localize(['connection already in this room (%s)', room])
+        return connection.localize(['connection already in this room ({{room}})', {room: room}])
       },
 
       connectionRoomHasBeenDeleted: function (room) {

--- a/config/errors.js
+++ b/config/errors.js
@@ -60,7 +60,7 @@ exports['default'] = {
 
       // user requested an unknown action
       unknownAction: function (data) {
-        return data.connection.localize('actionhero.errors.unknownActionAction')
+        return data.connection.localize('actionhero.errors.unknownAction')
       },
 
       // action not useable by this client/server type

--- a/config/i18n.js
+++ b/config/i18n.js
@@ -13,7 +13,8 @@ exports['default'] = {
       // configure i18n to allow for object-style key lookup
       objectNotation: true,
 
-      updateFiles: false,
+      // should actionhero append any missing translations to the locale file?
+      updateFiles: true,
 
       // this will configure logging and error messages in the log(s)
       defaultLocale: 'en',
@@ -29,7 +30,7 @@ exports['default'] = {
 exports.test = {
   i18n: function (api) {
     return {
-      updateFiles: true
+      updateFiles: false
     }
   }
 }

--- a/config/i18n.js
+++ b/config/i18n.js
@@ -25,3 +25,11 @@ exports['default'] = {
     }
   }
 }
+
+exports.test = {
+  i18n: function (api) {
+    return {
+      updateFiles: true
+    }
+  }
+}

--- a/config/i18n.js
+++ b/config/i18n.js
@@ -10,6 +10,9 @@ exports['default'] = {
         // 'es': 'en'
       },
 
+      // configure i18n to allow for object-style key lookup
+      objectNotation: true,
+
       updateFiles: true,
 
       // this will configure logging and error messages in the log(s)

--- a/config/i18n.js
+++ b/config/i18n.js
@@ -30,7 +30,7 @@ exports['default'] = {
 exports.test = {
   i18n: function (api) {
     return {
-      updateFiles: false
+      updateFiles: true
     }
   }
 }

--- a/config/i18n.js
+++ b/config/i18n.js
@@ -13,7 +13,7 @@ exports['default'] = {
       // configure i18n to allow for object-style key lookup
       objectNotation: true,
 
-      updateFiles: true,
+      updateFiles: false,
 
       // this will configure logging and error messages in the log(s)
       defaultLocale: 'en',
@@ -22,14 +22,6 @@ exports['default'] = {
       // by default, every request will be in the 'en' locale
       // this method will be called witin the localiazation middleware on all requests
       determineConnectionLocale: 'api.i18n.determineConnectionLocale'
-    }
-  }
-}
-
-exports.staging = {
-  i18n: function () {
-    return {
-      updateFiles: false
     }
   }
 }

--- a/config/logger.js
+++ b/config/logger.js
@@ -41,9 +41,6 @@ exports['default'] = {
     // the maximum length of param to log (we will truncate)
     logger.maxLogStringLength = 100
 
-    // should system logs (api.log) be localized?
-    logger.localizeLogMessages = false
-
     // you can optionally set custom log levels
     // logger.levels = {good: 0, bad: 1};
 

--- a/config/servers/socket.js
+++ b/config/servers/socket.js
@@ -18,9 +18,7 @@ exports['default'] = {
         // Delimiter string for incoming messages
         delimiter: '\n',
         // Maximum incoming message string length in Bytes (use 0 for Infinite)
-        maxDataLength: 0,
-        // What message to send down to a client who requests a `quit`
-        goodbyeMessage: 'Bye!'
+        maxDataLength: 0
       }
     }
   }

--- a/docs/_includes/docs/core/localization.html
+++ b/docs/_includes/docs/core/localization.html
@@ -52,7 +52,7 @@ module.exports = {
   <ul>
     <li><code>connection.localize(string)</code> or <code>connection.localize([string-with-interpolation, value])</code>
       <ul>
-        <li>Allows you to interpolate a string based on the connection's current locale.  For example, say in an action you wanted to respond with <code>data.response.message = connection.localize('the count was {{count}}', {count: 4});</code> In your locale files, you would define <code>the count was %s</code> in every language you cared about, and not need to modify the action itself at all.</li>
+        <li>Allows you to interpolate a string based on the connection's current locale.  For example, say in an action you wanted to respond with <code>data.response.message = connection.localize('the count was {{count}}', {count: 4});</code> In your locale files, you would define <code>the count was {{count}}</code> in every language you cared about, and not need to modify the action itself at all.</li>
       </ul>
     </li>
   </ul>
@@ -62,8 +62,8 @@ module.exports = {
   <ul>
     <li>Just like connections, the ActionHero logger itself now has localization interpolation built in.  Note how in the new settings you set which locale you want the server's logs to be expressed in.  Using that, you can now use sprintf-style string interpolation as the first argument of <code>api.log()</code>
       <ul>
-        <li>You might want to log the message <code>api.log(['The time is %s', new Date()], 'alert')</code>.</li>
-        <li>Changing the translation of the string <code>The time is %s</code> in your locale files would apply to the logger as well!</li>
+        <li>You might want to log the message <code>api.log(['The time is {{date}}', {date: new Date()}], 'alert')</code>.</li>
+        <li>Changing the translation of the string <code>The time is {{date}}</code> in your locale files would apply to the logger as well!</li>
         <li>You can of course continue to log plain strings as we have been with the logger as well.</li>
       </ul>
     </li>

--- a/docs/_includes/docs/core/localization.html
+++ b/docs/_includes/docs/core/localization.html
@@ -52,7 +52,7 @@ module.exports = {
   <ul>
     <li><code>connection.localize(string)</code> or <code>connection.localize([string-with-interpolation, value])</code>
       <ul>
-        <li>Allows you to interpolate a string based on the connection's current locale.  For example, say in an action you wanted to respond with <code>data.response.message = connection.localize('the count was %s', 4);</code> In your locale files, you would define <code>the count was %s</code> in every language you cared about, and not need to modify the action itself at all.</li>
+        <li>Allows you to interpolate a string based on the connection's current locale.  For example, say in an action you wanted to respond with <code>data.response.message = connection.localize('the count was {{count}}', {count: 4});</code> In your locale files, you would define <code>the count was %s</code> in every language you cared about, and not need to modify the action itself at all.</li>
       </ul>
     </li>
   </ul>

--- a/docs/_includes/docs/core/localization.html
+++ b/docs/_includes/docs/core/localization.html
@@ -72,7 +72,7 @@ module.exports = {
   <h2 id="localization-localizing-other-strings">Localizing other strings</h2>
 
   <ul>
-    <li>To localize strings that are not used in methods mentioned above you can use <code>api.i18n.localize(string, options)</code> or <code>api.i18n.localize([string-with-interpolation, value], options)</code>.
+    <li>To localize strings that are not used in methods mentioned above you can use <code>api.i18n.localize(string, options)</code>.
       <ul>
         <li>Allows you to interpolate a string.</li>
         <li>Just as the other localize methods above, the input string will be in your locale files for you to change it anytime you want.</li>

--- a/docs/_includes/docs/core/logging.html
+++ b/docs/_includes/docs/core/logging.html
@@ -72,22 +72,5 @@ api.log('OH NO!', 'warning');
 
 // custom severity with a metadata object
 api.log('OH NO, something went wrong', 'warning', { error: new Error('things are busted') });
-
-// using sprintf-style interpolations
-var message = ['Hello there, the time is now %s', new Date()];
-api.log(message, 'debug');
   {% endhighlight %}
-
-  <ul>
-    <li>message is a string or an array containing a <code>sprintf</code> style string and replacements
-      <ul>
-        <li>an example of this would be: <code>api.log(['Hello %s', connection.params.firstName], 'info')</code></li>
-        <li>the message you pass will be used with the localization engines (<code>i18n</code>).  You can <a href="/docs/core/#localization-localizing-the-logger">learn more here</a></li>
-      </ul>
-    </li>
-    <li>severity is a string, and should match the log-level (IE: ‘info' or ‘warning')</li>
-    <li>the default severity level is ‘info'</li>
-    <li>(optional) metadata is anything that can be stringified with <code>JSON.stringify</code></li>
-  </ul>
-
 </section>

--- a/initializers/actionProcessor.js
+++ b/initializers/actionProcessor.js
@@ -132,7 +132,7 @@ module.exports = {
         }
       }
 
-      api.log(['[ action @ %s ]', this.connection.type], logLevel, logLine)
+      api.log(`[ action @ ${this.connection.type} ]`, logLevel, logLine)
     }
 
     api.ActionProcessor.prototype.preProcessAction = function (callback) {

--- a/initializers/actions.js
+++ b/initializers/actions.js
@@ -52,9 +52,9 @@ module.exports = {
 
       const loadMessage = (action) => {
         if (reload) {
-          api.log(['action reloaded: %s @ v%s, %s', action.name, action.version, fullFilePath], 'debug')
+          api.log(`action reloaded: ${action.name} @ v${action.version}, ${fullFilePath}`, 'debug')
         } else {
-          api.log(['action loaded: %s @ v%s, %s', action.name, action.version, fullFilePath], 'debug')
+          api.log(`action loaded: ${action.name} @ v${action.version}, ${fullFilePath}`, 'debug')
         }
       }
 

--- a/initializers/cache.js
+++ b/initializers/cache.js
@@ -125,7 +125,7 @@ module.exports = {
         try { cacheObj = JSON.parse(cacheObj) } catch (e) {}
         if (!cacheObj) {
           if (typeof callback === 'function') {
-            return callback(new Error(api.i18n.localize('Object not found')), null, null, null, null)
+            return callback(new Error(api.i18n.localize('actionhero.cache.objectNotFound')), null, null, null, null)
           }
         } else if (cacheObj.expireTimestamp >= new Date().getTime() || cacheObj.expireTimestamp === null) {
           const lastReadAt = cacheObj.readAt
@@ -142,7 +142,7 @@ module.exports = {
 
           api.cache.checkLock(key, options.retry, function (error, lockOk) {
             if (error || lockOk !== true) {
-              if (typeof callback === 'function') { return callback(new Error(api.i18n.localize('Object Locked'))) }
+              if (typeof callback === 'function') { return callback(new Error(api.i18n.localize('actionhero.cache.objectLocked'))) }
             } else {
               redis.set(api.cache.redisPrefix + key, JSON.stringify(cacheObj), (error) => {
                 if (typeof callback === 'function' && typeof expireTimeSeconds !== 'number') {
@@ -157,7 +157,7 @@ module.exports = {
           })
         } else {
           if (typeof callback === 'function') {
-            return callback(new Error(api.i18n.localize('Object Expired')))
+            return callback(new Error(api.i18n.localize('actionhero.cache.objectExpired')))
           }
         }
       })
@@ -166,7 +166,7 @@ module.exports = {
     api.cache.destroy = function (key, callback) {
       api.cache.checkLock(key, null, (error, lockOk) => {
         if (error || lockOk !== true) {
-          if (typeof callback === 'function') { callback(new Error(api.i18n.localize('Object Locked'))) }
+          if (typeof callback === 'function') { callback(new Error(api.i18n.localize('actionhero.cache.objectLocked'))) }
         } else {
           redis.del(api.cache.redisPrefix + key, (error, count) => {
             if (error) { api.log(error, 'error') }
@@ -200,7 +200,7 @@ module.exports = {
 
       api.cache.checkLock(key, null, function (error, lockOk) {
         if (error || lockOk !== true) {
-          if (typeof callback === 'function') { return callback(new Error(api.i18n.localize('Object Locked'))) }
+          if (typeof callback === 'function') { return callback(new Error(api.i18n.localize('actionhero.cache.objectLocked'))) }
         } else {
           redis.set(api.cache.redisPrefix + key, JSON.stringify(cacheObj), (error) => {
             if (!error && expireTimeSeconds) {

--- a/initializers/chatRoom.js
+++ b/initializers/chatRoom.js
@@ -305,7 +305,7 @@ module.exports = {
 
     if (api.config.general.startingChatRooms) {
       for (let room in api.config.general.startingChatRooms) {
-        api.log(['ensuring the existence of the chatRoom: %s', room])
+        api.log(`ensuring the existence of the chatRoom: ${room}`)
         api.chatRoom.add(room)
       }
     }

--- a/initializers/config.js
+++ b/initializers/config.js
@@ -98,7 +98,7 @@ module.exports = {
     }
 
     const rebootCallback = (file) => {
-      api.log(['*** rebooting due to config change (%s) ***', file], 'info')
+      api.log(`*** rebooting due to config change (${file}) ***`, 'info')
       delete require.cache[require.resolve(file)]
       api.commands.restart()
     }
@@ -172,7 +172,7 @@ module.exports = {
   },
 
   start: function (api, callback) {
-    api.log(['environment: %s', api.env], 'notice')
+    api.log(`environment: ${api.env}`, 'notice')
     callback()
   }
 

--- a/initializers/genericServer.js
+++ b/initializers/genericServer.js
@@ -112,7 +112,7 @@ module.exports = {
     }
 
     api.GenericServer.prototype.log = function (message, severity, data) {
-      api.log(['[server: %s] %s', this.type, message], severity, data)
+      api.log(`[server: ${this.type}] ${message}`, severity, data)
     }
 
     const methodNotDefined = function () {

--- a/initializers/genericServer.js
+++ b/initializers/genericServer.js
@@ -72,13 +72,13 @@ module.exports = {
       }
 
       if (this.attributes.sendWelcomeMessage === true) {
-        connection.sendMessage({welcome: api.config.general.welcomeMessage, context: 'api'})
+        connection.sendMessage({welcome: connection.localize('actionhero.welcomeMessage'), context: 'api'})
       }
 
       if (typeof this.attributes.sendWelcomeMessage === 'number') {
         setTimeout(() => {
           try {
-            connection.sendMessage({welcome: api.config.general.welcomeMessage, context: 'api'})
+            connection.sendMessage({welcome: connection.localize('actionhero.welcomeMessage'), context: 'api'})
           } catch (e) {
             api.log(e, 'error')
           }

--- a/initializers/id.js
+++ b/initializers/id.js
@@ -36,7 +36,7 @@ module.exports = {
   },
 
   start: function (api, next) {
-    api.log(['server ID: %s', api.id], 'notice')
+    api.log(`server ID: ${api.id}`, 'notice')
     next()
   }
 }

--- a/initializers/logger.js
+++ b/initializers/logger.js
@@ -30,17 +30,8 @@ module.exports = {
     }
 
     api.log = function (message, severity, data) {
-      let localizedMessage
-      if (api.config.logger.localizeLogMessages === true) {
-        localizedMessage = api.i18n.localize(message)
-      } else if (typeof message === 'string') {
-        localizedMessage = message
-      } else {
-        localizedMessage = util.format.apply(this, message)
-      }
-
       if (severity === undefined || severity === null || api.logger.levels[severity] === undefined) { severity = 'info' }
-      let args = [severity, localizedMessage]
+      let args = [severity, message]
       if (data !== null && data !== undefined) { args.push(data) }
       api.logger.log.apply(api.logger, args)
     }

--- a/initializers/logger.js
+++ b/initializers/logger.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const util = require('util')
 const winston = require('winston')
 
 module.exports = {
@@ -39,7 +38,6 @@ module.exports = {
     let logLevels = []
     for (i in api.logger.levels) { logLevels.push(i) }
 
-    api.log('*** Starting ActionHero ***', 'notice')
     api.log('Logger loaded.  Possible levels include:', 'debug', logLevels)
 
     next()

--- a/initializers/pids.js
+++ b/initializers/pids.js
@@ -16,7 +16,7 @@ module.exports = {
       pidfile = pidfile.replace(new RegExp(':', 'g'), '-')
       pidfile = pidfile.replace(new RegExp(' ', 'g'), '_')
       pidfile = pidfile.replace(new RegExp('\r', 'g'), '') // eslint-disable-line
-      pidfile = pidfile.replace(new RegExp('\n', 'g'), '') // eslint-disable-line 
+      pidfile = pidfile.replace(new RegExp('\n', 'g'), '') // eslint-disable-line
 
       return pidfile
     }
@@ -46,7 +46,7 @@ module.exports = {
 
   start: function (api, next) {
     api.pids.writePidFile()
-    api.log(['pid: %s', process.pid], 'notice')
+    api.log(`pid: ${process.pid}`, 'notice')
     next()
   }
 }

--- a/initializers/redis.js
+++ b/initializers/redis.js
@@ -25,13 +25,13 @@ module.exports = {
           if (api.config.redis[r].buildNew === true) {
             const args = api.config.redis[r].args
             api.redis.clients[r] = new api.config.redis[r].konstructor(args[0], args[1], args[2]) // eslint-disable-line
-            api.redis.clients[r].on('error', (error) => { api.log(['Redis connection `%s` error', r], 'error', error) })
-            api.redis.clients[r].on('connect', () => { api.log(['Redis connection `%s` connected', r], 'debug') })
+            api.redis.clients[r].on('error', (error) => { api.log(`Redis connection \`${r}\` error`, 'error', error) })
+            api.redis.clients[r].on('connect', () => { api.log(`Redis connection \`${r}\` connected`, 'debug') })
             api.redis.clients[r].once('connect', done)
           } else {
             api.redis.clients[r] = api.config.redis[r].konstructor.apply(null, api.config.redis[r].args)
-            api.redis.clients[r].on('error', (error) => { api.log(['Redis connection `%s` error', r], 'error', error) })
-            api.log(['Redis connection `%s` connected', r], 'debug')
+            api.redis.clients[r].on('error', (error) => { api.log(`Redis connection \`${r}\` error`, 'error', error) })
+            api.log(`Redis connection \`${r}\` connected`, 'debug')
             done()
           }
         })
@@ -148,7 +148,7 @@ module.exports = {
   },
 
   start: function (api, next) {
-    api.redis.doCluster('api.log', [['actionhero member %s has joined the cluster', api.id]], null, null)
+    api.redis.doCluster('api.log', [`actionhero member ${api.id} has joined the cluster`], null, null)
     next()
   },
 
@@ -158,7 +158,7 @@ module.exports = {
       delete api.redis.clusterCallbakTimeouts[i]
       delete api.redis.clusterCallbaks[i]
     }
-    api.redis.doCluster('api.log', [['actionhero member %s has left the cluster', api.id]], null, null)
+    api.redis.doCluster('api.log', [`actionhero member ${api.id} has left the cluster`], null, null)
 
     process.nextTick(function () {
       api.redis.clients.subscriber.unsubscribe()

--- a/initializers/resque.js
+++ b/initializers/resque.js
@@ -47,9 +47,9 @@ module.exports = {
             this.scheduler.on('start', () => { api.log('resque scheduler started', this.schedulerLogging.start) })
             this.scheduler.on('end', () => { api.log('resque scheduler ended', this.schedulerLogging.end) })
             this.scheduler.on('poll', () => { api.log('resque scheduler polling', this.schedulerLogging.poll) })
-            this.scheduler.on('working_timestamp', (timestamp) => { api.log(['resque scheduler working timestamp %s', timestamp], this.schedulerLogging.working_timestamp) })
-            this.scheduler.on('transferred_job', (timestamp, job) => { api.log(['resque scheduler enqueuing job %s', timestamp], this.schedulerLogging.transferred_job, job) })
-            this.scheduler.on('master', (state) => { api.log(['This node is now the Resque scheduler master']) })
+            this.scheduler.on('working_timestamp', (timestamp) => { api.log(`resque scheduler working timestamp ${timestamp}`, this.schedulerLogging.working_timestamp) })
+            this.scheduler.on('transferred_job', (timestamp, job) => { api.log(`resque scheduler enqueuing job ${timestamp}`, this.schedulerLogging.transferred_job, job) })
+            this.scheduler.on('master', (state) => { api.log('This node is now the Resque scheduler master') })
 
             this.scheduler.start()
             callback()
@@ -90,11 +90,11 @@ module.exports = {
         // normal worker emitters
         this.multiWorker.on('start', (workerId) => { api.log('worker: started', this.workerLogging.start, {workerId: workerId}) })
         this.multiWorker.on('end', (workerId) => { api.log('worker: ended', this.workerLogging.end, {workerId: workerId}) })
-        this.multiWorker.on('cleaning_worker', (workerId, worker, pid) => { api.log(['worker: cleaning old worker %s, (%s)', worker, pid], this.workerLogging.cleaning_worker) })
-        this.multiWorker.on('poll', (workerId, queue) => { api.log(['worker: polling %s', queue], this.workerLogging.poll, {workerId: workerId}) })
-        this.multiWorker.on('job', (workerId, queue, job) => { api.log(['worker: working job %s', queue], this.workerLogging.job, {workerId: workerId, job: {class: job['class'], queue: job.queue}}) })
+        this.multiWorker.on('cleaning_worker', (workerId, worker, pid) => { api.log(`worker: cleaning old worker ${worker}, (${pid})`, this.workerLogging.cleaning_worker) })
+        this.multiWorker.on('poll', (workerId, queue) => { api.log(`worker: polling ${queue}`, this.workerLogging.poll, {workerId: workerId}) })
+        this.multiWorker.on('job', (workerId, queue, job) => { api.log(`worker: working job ${queue}`, this.workerLogging.job, {workerId: workerId, job: {class: job['class'], queue: job.queue}}) })
         this.multiWorker.on('reEnqueue', (workerId, queue, job, plugin) => { api.log('worker: reEnqueue job', this.workerLogging.reEnqueue, {workerId: workerId, plugin: plugin, job: {class: job['class'], queue: job.queue}}) })
-        this.multiWorker.on('success', (workerId, queue, job, result) => { api.log(['worker: job success %s', queue], this.workerLogging.success, {workerId: workerId, job: {class: job['class'], queue: job.queue}, result: result}) })
+        this.multiWorker.on('success', (workerId, queue, job, result) => { api.log(`worker: job success ${queue}`, this.workerLogging.success, {workerId: workerId, job: {class: job['class'], queue: job.queue}, result: result}) })
         this.multiWorker.on('pause', (workerId) => { api.log('worker: paused', this.workerLogging.pause, {workerId: workerId}) })
 
         this.multiWorker.on('failure', (workerId, queue, job, failure) => { api.exceptionHandlers.task(failure, queue, job, workerId) })
@@ -102,7 +102,7 @@ module.exports = {
 
         // multiWorker emitters
         this.multiWorker.on('internalError', (error) => { api.log(error, this.workerLogging.internalError) })
-        this.multiWorker.on('multiWorkerAction', (verb, delay) => { api.log(['*** checked for worker status: %s (event loop delay: %sms)', verb, delay], this.workerLogging.multiWorkerAction) })
+        this.multiWorker.on('multiWorkerAction', (verb, delay) => { api.log(`*** checked for worker status: ${verb} (event loop delay: ${delay}ms)`, this.workerLogging.multiWorkerAction) })
 
         if (api.config.tasks.minTaskProcessors > 0) {
           this.multiWorker.start(() => {

--- a/initializers/routes.js
+++ b/initializers/routes.js
@@ -142,7 +142,7 @@ module.exports = {
       }
 
       api.params.postVariables = api.utils.arrayUniqueify(api.params.postVariables)
-      api.log(['%s routes loaded from %s', counter, api.routes.routesFile], 'debug')
+      api.log(`${counter} routes loaded from ${api.routes.routesFile}`, 'debug')
 
       if (api.config.servers.web && api.config.servers.web.simpleRouting === true) {
         let simplePaths = []
@@ -154,7 +154,7 @@ module.exports = {
             api.routes.registerRoute(verb, '/' + action, action)
           }
         }
-        api.log(['%s simple routes loaded from action names', simplePaths.length], 'debug')
+        api.log(`${simplePaths.length} simple routes loaded from action names`, 'debug')
 
         api.log('routes:', 'debug', api.routes.routes)
       }

--- a/initializers/servers.js
+++ b/initializers/servers.js
@@ -36,13 +36,13 @@ module.exports = {
           jobs.push((done) => {
             init(api, options, (serverObject) => {
               api.servers.servers[serverName] = serverObject
-              api.log(['Initialized server: %s', serverName], 'debug')
+              api.log(`Initialized server: ${serverName}`, 'debug')
               return done()
             })
           })
         }
         api.watchFileAndAct(f, () => {
-          api.log(['*** Rebooting due to server (%s) change ***', serverName], 'info')
+          api.log(`*** Rebooting due to server (${serverName}) change ***`, 'info')
           api.commands.restart()
         })
       })
@@ -57,23 +57,19 @@ module.exports = {
       let server = api.servers.servers[serverName]
       if (server && server.options.enabled === true) {
         let message = ''
-        let messageArgs = []
-        message += 'Starting server: `%s`'
-        messageArgs.push(serverName)
+        message += `Starting server: \`${serverName}\``
         if (api.config.servers[serverName].bindIP) {
-          message += ' @ %s'
-          messageArgs.push(api.config.servers[serverName].bindIP)
+          message += ` @ ${api.config.servers[serverName].bindIP}`
         }
         if (api.config.servers[serverName].port) {
-          message += ':%s'
-          messageArgs.push(api.config.servers[serverName].port)
+          message += `:${api.config.servers[serverName].port}`
         }
 
         jobs.push((done) => {
-          api.log([message].concat(messageArgs), 'notice')
+          api.log(message, 'notice')
           server.start((error) => {
             if (error) { return done(error) }
-            api.log(['Server started: %s', serverName], 'debug')
+            api.log(`Server started: ${serverName}`, 'debug')
             return done()
           })
         })
@@ -89,10 +85,10 @@ module.exports = {
       let server = api.servers.servers[serverName]
       if ((server && server.options.enabled === true) || !server) {
         jobs.push((done) => {
-          api.log(['Stopping server: %s', serverName], 'notice')
+          api.log(`Stopping server: ${serverName}`, 'notice')
           server.stop((error) => {
             if (error) { return done(error) }
-            api.log(['Server stopped: %s', serverName], 'debug')
+            api.log(`Server stopped: ${serverName}`, 'debug')
             return done()
           })
         })

--- a/initializers/staticFile.js
+++ b/initializers/staticFile.js
@@ -107,7 +107,7 @@ module.exports = {
       },
 
       logRequest: function (file, connection, length, duration, success) {
-        api.log(['[ file @ %s ]', connection.type], api.config.general.fileRequestLogLevel, {
+        api.log(`[ file @ ${connection.type} ]`, api.config.general.fileRequestLogLevel, {
           to: connection.remoteIP,
           file: file,
           requestedFile: connection.params.file,

--- a/initializers/tasks.js
+++ b/initializers/tasks.js
@@ -17,7 +17,7 @@ module.exports = {
         if (!reload) { reload = false }
 
         const loadMessage = function (loadedTaskName) {
-          api.log(['task %s loaded: %s, %s', (reload ? '(re)' : ''), loadedTaskName, fullFilePath], 'debug')
+          api.log(`task ${(reload ? '(re)' : '')} loaded: ${loadedTaskName}, ${fullFilePath}`, 'debug')
         }
 
         api.watchFileAndAct(fullFilePath, () => {
@@ -247,7 +247,7 @@ module.exports = {
           this.del(task.queue, taskName, {}, () => {
             this.delDelayed(task.queue, taskName, {}, () => {
               this.enqueueIn(task.frequency, taskName, () => {
-                api.log(['re-enqueued recurrent job %s', taskName], api.config.tasks.schedulerLogging.reEnqueue)
+                api.log(`re-enqueued recurrent job ${taskName}`, api.config.tasks.schedulerLogging.reEnqueue)
                 callback()
               })
             })
@@ -266,7 +266,7 @@ module.exports = {
               this.enqueue(taskName, (error, toRun) => {
                 if (error) { return done(error) }
                 if (toRun === true) {
-                  api.log(['enqueuing periodic task: %s', taskName], api.config.tasks.schedulerLogging.enqueue)
+                  api.log(`enqueuing periodic task: ${taskName}`, api.config.tasks.schedulerLogging.enqueue)
                   loadedTasks.push(taskName)
                 }
                 return done()

--- a/initializers/utils.js
+++ b/initializers/utils.js
@@ -127,7 +127,7 @@ module.exports = {
                   child.forEach((c) => { results.push(c) })
                 } else {
                   try {
-                    api.log(['cannot find linked refrence to `%s`', file], 'warning')
+                    api.log(`cannot find linked refrence to \`${file}\``, 'warning')
                   } catch (e) {
                     throw new Error('cannot find linked refrence to ' + file)
                   }
@@ -303,21 +303,21 @@ module.exports = {
 
     api.utils.createDirSafely = function (dir) {
       if (api.utils.dirExists(dir)) {
-        api.log([' - directory \'%s\' already exists, skipping', path.normalize(dir)], 'alert')
+        api.log(` - directory '${path.normalize(dir)}' already exists, skipping`, 'alert')
       } else {
-        api.log([' - creating directory \'%s\'', path.normalize(dir)])
+        api.log(` - creating directory '${path.normalize(dir)}'`)
         fs.mkdirSync(path.normalize(dir), '0766')
       }
     }
 
     api.utils.createFileSafely = function (file, data, overwrite) {
       if (api.utils.fileExists(file) && !overwrite) {
-        api.log([' - file \'%s\' already exists, skipping', path.normalize(file)], 'alert')
+        api.log(` - file '${path.normalize(file)}' already exists, skipping`, 'alert')
       } else {
         if (overwrite && api.utils.fileExists(file)) {
-          api.log([' - overwritten file \'%s\'', path.normalize(file)])
+          api.log(` - overwritten file '${path.normalize(file)}'`)
         } else {
-          api.log([' - wrote file \'%s\'', path.normalize(file)])
+          api.log(` - wrote file '${path.normalize(file)}'`)
         }
         fs.writeFileSync(path.normalize(file), data)
       }
@@ -325,27 +325,27 @@ module.exports = {
 
     api.utils.createLinkfileSafely = function (filePath, type, refrence) {
       if (api.utils.fileExists(filePath)) {
-        api.log([' - link file \'%s\' already exists, skipping', filePath], 'alert')
+        api.log(` - link file '${filePath}' already exists, skipping`, 'alert')
       } else {
-        api.log([' - creating linkfile \'%s\'', filePath])
+        api.log(` - creating linkfile '${filePath}'`)
         fs.writeFileSync(filePath, type)
       }
     }
 
     api.utils.removeLinkfileSafely = function (filePath, type, refrence) {
       if (!api.utils.fileExists(filePath)) {
-        api.log([' - link file \'%s\' doesn\'t exist, skipping', filePath], 'alert')
+        api.log(` - link file '${filePath}' doesn't exist, skipping`, 'alert')
       } else {
-        api.log([' - removing linkfile \'%s\'', filePath])
+        api.log(` - removing linkfile '${filePath}'`)
         fs.unlinkSync(filePath)
       }
     }
 
     api.utils.createSymlinkSafely = function (destination, source) {
       if (api.utils.dirExists(destination)) {
-        api.log([' - symbolic link \'%s\' already exists, skipping', destination], 'alert')
+        api.log(` - symbolic link '${destination}' already exists, skipping`, 'alert')
       } else {
-        api.log([' - creating symbolic link \'%s\' => \'%s\'', destination, source])
+        api.log(` - creating symbolic link '${destination}' => '${source}'`)
         fs.symlinkSync(source, destination, 'dir')
       }
     }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,7 +1,7 @@
 {
 	"actionhero": {
 		"welcomeMessage": "Hello! Welcome to the actionhero api",
-    "goodbyeMessage": "Bye!",
+		"goodbyeMessage": "Bye!",
 		"errors": {
 			"invalidParams": "validation error",
 			"missingParams": "{{param}} is a required parameter for this action",
@@ -13,15 +13,21 @@
 			"fileNotFound": "That file is not found",
 			"fileNotProvided": "file is a required param to send a file",
 			"fileReadError": "error reading file: {{error}}",
-      "verbNotFound": "I do not know know to perform this verb ({{verb}})",
-      "verbNotAllowed": "verb not found or not allowed ({{verb}})",
-      "connectionRoomAndMessage": "both room and message are required",
-      "connectionNotInRoom": "connection not in this room ({{room}})",
-      "connectionAlreadyInRoom": "connection already in this room ({{room}})",
-      "connectionRoomHasBeenDeleted": "this room has been deleted",
-      "connectionRoomNotExist": "room does not exist",
-      "connectionRoomExists": "room exists",
-      "connectionRoomRequired": "a room is required"
+			"verbNotFound": "I do not know know to perform this verb ({{verb}})",
+			"verbNotAllowed": "verb not found or not allowed ({{verb}})",
+			"connectionRoomAndMessage": "both room and message are required",
+			"connectionNotInRoom": "connection not in this room ({{room}})",
+			"connectionAlreadyInRoom": "connection already in this room ({{room}})",
+			"connectionRoomHasBeenDeleted": "this room has been deleted",
+			"connectionRoomNotExist": "room does not exist",
+			"connectionRoomExists": "room exists",
+			"connectionRoomRequired": "a room is required",
+			"unknownActionAction": "actionhero.errors.unknownActionAction"
 		}
-	}
+	},
+	"Your random number is {{number}}": "Your random number is {{number}}",
+	"Node Healthy": "Node Healthy",
+	"Object not found": "Object not found",
+	"Object Expired": "Object Expired",
+	"Object Locked": "Object Locked"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,7 +1,27 @@
 {
 	"actionhero": {
-		"ActionHero": "ActionHero",
-		"welcomeMessage": "Hello! Welcome to the actionhero api"
-	},
-	"Your random number is {{number}}": "Your random number is {{number}}"
+		"welcomeMessage": "Hello! Welcome to the actionhero api",
+    "goodbyeMessage": "Bye!",
+		"errors": {
+			"invalidParams": "validation error",
+			"missingParams": "{{param}} is a required parameter for this action",
+			"unknownAction": "unknown action or invalid apiVersion",
+			"unsupportedServerType": "this action does not support the {{type}} connection type",
+			"serverShuttingDown": "the server is shutting down",
+			"tooManyPendingActions": "you have too many pending requests",
+			"dataLengthTooLarge": "data length is too big ({{maxLength}} received/{{receivedLength}} max)",
+			"fileNotFound": "That file is not found",
+			"fileNotProvided": "file is a required param to send a file",
+			"fileReadError": "error reading file: {{error}}",
+      "verbNotFound": "I do not know know to perform this verb ({{verb}})",
+      "verbNotAllowed": "verb not found or not allowed ({{verb}})",
+      "connectionRoomAndMessage": "both room and message are required",
+      "connectionNotInRoom": "connection not in this room ({{room}})",
+      "connectionAlreadyInRoom": "connection already in this room ({{room}})",
+      "connectionRoomHasBeenDeleted": "this room has been deleted",
+      "connectionRoomNotExist": "room does not exist",
+      "connectionRoomExists": "room exists",
+      "connectionRoomRequired": "a room is required"
+		}
+	}
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -2,6 +2,11 @@
 	"actionhero": {
 		"welcomeMessage": "Hello! Welcome to the actionhero api",
 		"goodbyeMessage": "Bye!",
+		"cache": {
+			"objectNotFound": "Object not found",
+			"objectLocked": "Object locked",
+			"objectExpired": "Object expired"
+		},
 		"errors": {
 			"invalidParams": "validation error",
 			"missingParams": "{{param}} is a required parameter for this action",
@@ -21,13 +26,7 @@
 			"connectionRoomHasBeenDeleted": "this room has been deleted",
 			"connectionRoomNotExist": "room does not exist",
 			"connectionRoomExists": "room exists",
-			"connectionRoomRequired": "a room is required",
-			"unknownActionAction": "actionhero.errors.unknownActionAction"
+			"connectionRoomRequired": "a room is required"
 		}
-	},
-	"Your random number is {{number}}": "Your random number is {{number}}",
-	"Node Healthy": "Node Healthy",
-	"Object not found": "Object not found",
-	"Object Expired": "Object Expired",
-	"Object Locked": "Object Locked"
+	}
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,7 @@
+{
+	"actionhero": {
+		"ActionHero": "ActionHero",
+		"welcomeMessage": "Hello! Welcome to the actionhero api"
+	},
+	"Your random number is {{number}}": "Your random number is {{number}}"
+}

--- a/servers/socket.js
+++ b/servers/socket.js
@@ -80,7 +80,7 @@ const initialize = function (api, options, next) {
     try {
       connection.rawConnection.write(JSON.stringify(message) + '\r\n')
     } catch (e) {
-      api.log(['socket write error: %s', e], 'error')
+      api.log(`socket write error: ${e}`, 'error')
     }
   }
 

--- a/servers/socket.js
+++ b/servers/socket.js
@@ -86,7 +86,7 @@ const initialize = function (api, options, next) {
 
   server.goodbye = function (connection) {
     try {
-      connection.rawConnection.end(JSON.stringify({status: connection.localize(api.config.servers.socket.goodbyeMessage), context: 'api'}) + '\r\n')
+      connection.rawConnection.end(JSON.stringify({status: connection.localize('actionhero.goodbyeMessage'), context: 'api'}) + '\r\n')
     } catch (e) {}
   }
 

--- a/servers/websocket.js
+++ b/servers/websocket.js
@@ -48,7 +48,7 @@ const initialize = function (api, options, next) {
       handleDisconnection(rawConnection)
     })
 
-    api.log(['webSockets bound to %s: %s', webserver.options.bindIP, webserver.options.port], 'debug')
+    api.log(`webSockets bound to ${webserver.options.bindIP}: ${webserver.options.port}`, 'debug')
     server.active = true
 
     server.writeClientJS()
@@ -181,9 +181,9 @@ const initialize = function (api, options, next) {
           fs.mkdirSync(clientJSPath)
         }
         fs.writeFileSync(clientJSFullPath + '.js', server.renderClientJS(false))
-        api.log(['wrote %s.js', clientJSFullPath], 'debug')
+        api.log(`wrote ${clientJSFullPath}.js`, 'debug')
         fs.writeFileSync(clientJSFullPath + '.min.js', server.renderClientJS(true))
-        api.log(['wrote %s.min.js', clientJSFullPath], 'debug')
+        api.log(`wrote ${clientJSFullPath}.min.js`, 'debug')
       } catch (e) {
         api.log('Cannot write client-side JS for websocket server:', 'warning')
         api.log(e, 'warning')

--- a/test/core/cache.js
+++ b/test/core/cache.js
@@ -90,7 +90,7 @@ describe('Core: Cache', () => {
       expect(saveResp).to.equal(true)
       setTimeout(() => {
         api.cache.load('testKey_slow', (error, loadResp) => {
-          expect(String(error)).to.equal('Error: Object Expired')
+          expect(String(error)).to.equal('Error: Object expired')
           expect(loadResp).to.not.exist()
           done()
         })
@@ -340,7 +340,7 @@ describe('Core: Cache', () => {
         expect(lockOk).to.equal(true)
         api.cache.lockName = 'otherId'
         api.cache.save(key, 'value', (error) => {
-          expect(String(error)).to.equal('Error: Object Locked')
+          expect(String(error)).to.equal('Error: Object locked')
           done()
         })
       })
@@ -352,7 +352,7 @@ describe('Core: Cache', () => {
         expect(lockOk).to.equal(true)
         api.cache.lockName = 'otherId'
         api.cache.destroy(key, (error) => {
-          expect(String(error)).to.equal('Error: Object Locked')
+          expect(String(error)).to.equal('Error: Object locked')
           done()
         })
       })

--- a/test/core/i18n.js
+++ b/test/core/i18n.js
@@ -29,9 +29,9 @@ describe('Core: i18n', () => {
 
   before((done) => {
     var spanish = {
-      'Your random number is %s': 'Su número aleatorio es %s',
+      'Your random number is {{number}}': 'Su número aleatorio es {{number}}',
       'That file is not found': 'Ese archivo no se encuentra',
-      '%s is a required parameter for this action': '%s es un parámetro requerido para esta acción'
+      '{{param}} is a required parameter for this action': '{{param}} es un parámetro requerido para esta acción'
     }
     fs.writeFileSync(tmpPath + 'es.json', JSON.stringify(spanish))
 

--- a/test/core/i18n.js
+++ b/test/core/i18n.js
@@ -59,7 +59,7 @@ describe('Core: i18n', () => {
       expect(response.randomNumber).to.be.at.least(0)
       var content = readLocaleFile();
       [
-        'Your random number is %s'
+        'Your random number is {{number}}'
       ].forEach((s) => {
         expect(content[s]).to.equal(s)
       })

--- a/test/core/i18n.js
+++ b/test/core/i18n.js
@@ -11,15 +11,24 @@ var ActionheroPrototype = require(path.join(__dirname, '/../../actionhero.js'))
 var actionhero = new ActionheroPrototype()
 var api
 
-var tmpPath = require('os').tmpdir() + require('path').sep + 'locales' + require('path').sep
-
 var readLocaleFile = (locale) => {
-  if (!locale) { locale = api.config.i18n.defaultLocale }
   var file = api.config.general.paths.locale[0] + '/' + locale + '.json'
   var contents = String(fs.readFileSync(file))
   var json = JSON.parse(contents)
   return json
 }
+
+var spanish = {
+  'Your random number is {{number}}': 'Su número aleatorio es {{number}}',
+  actionhero: {
+    errors: {
+      missingParams: '{{param}} es un parámetro requerido para esta acción',
+      fileNotFound: 'Ese archivo no se encuentra'
+    }
+  }
+}
+
+fs.writeFileSync(path.join(__dirname, '/../../locales/test-env-es.json'), JSON.stringify(spanish, null, 2))
 
 describe('Core: i18n', () => {
   before((done) => {
@@ -28,26 +37,21 @@ describe('Core: i18n', () => {
   })
 
   before((done) => {
-    var spanish = {
-      'Your random number is {{number}}': 'Su número aleatorio es {{number}}',
-      'That file is not found': 'Ese archivo no se encuentra',
-      '{{param}} is a required parameter for this action': '{{param}} es un parámetro requerido para esta acción'
-    }
-    fs.writeFileSync(tmpPath + 'es.json', JSON.stringify(spanish))
-
     actionhero.start((error, a) => {
       expect(error).to.be.null()
       api = a
       var options = api.config.i18n
       options.directory = api.config.general.paths.locale[0]
-      options.locales = ['en', 'es']
+      options.locales = ['test-env-en', 'test-env-es']
+      options.defaultLocale = 'test-env-en'
       api.i18n.configure(options)
       done()
     })
   })
 
   after((done) => {
-    // api.utils.deleteDirectorySync( api.config.general.paths.locale[0] );
+    // fs.unlinkSync(path.join(__dirname, '/../../locales/test-env-en.json'))
+    // fs.unlinkSync(path.join(__dirname, '/../../locales/test-env-es.json'))
     actionhero.stop(() => {
       done()
     })
@@ -57,7 +61,7 @@ describe('Core: i18n', () => {
     api.specHelper.runAction('randomNumber', (response) => {
       expect(response.randomNumber).to.be.at.most(1)
       expect(response.randomNumber).to.be.at.least(0)
-      var content = readLocaleFile();
+      var content = readLocaleFile('test-env-en');
       [
         'Your random number is {{number}}'
       ].forEach((s) => {
@@ -67,15 +71,12 @@ describe('Core: i18n', () => {
     })
   })
 
-  // to test this we would need to temporarliy enable logging for the test ENV...
-  it('should respect the content of the localization files for the server logs')
-
   it('should respect the content of the localization files for generic messages to connections', (done) => {
-    api.i18n.determineConnectionLocale = () => { return 'en' }
+    api.i18n.determineConnectionLocale = () => { return 'test-env-en' }
     api.specHelper.runAction('randomNumber', (response) => {
       expect(response.stringRandomNumber).to.match(/Your random number is/)
 
-      api.i18n.determineConnectionLocale = () => { return 'es' }
+      api.i18n.determineConnectionLocale = () => { return 'test-env-es' }
       api.specHelper.runAction('randomNumber', (response) => {
         expect(response.stringRandomNumber).to.match(/Su número aleatorio es/)
         done()
@@ -83,12 +84,12 @@ describe('Core: i18n', () => {
     })
   })
 
-  it('should respect the content of the localization files for api errors to connections', (done) => {
-    api.i18n.determineConnectionLocale = () => { return 'en' }
+  it('should respect the content of the localization files for api errors to connections or use defaults', (done) => {
+    api.i18n.determineConnectionLocale = () => { return 'test-env-en' }
     api.specHelper.runAction('cacheTest', (response) => {
-      expect(response.error).to.match(/key is a required parameter for this action/)
+      expect(response.error).to.equal('Error: actionhero.errors.missingParams')
 
-      api.i18n.determineConnectionLocale = () => { return 'es' }
+      api.i18n.determineConnectionLocale = () => { return 'test-env-es' }
       api.specHelper.runAction('cacheTest', (response) => {
         expect(response.error).to.match(/key es un parámetro requerido para esta acción/)
         done()
@@ -96,12 +97,12 @@ describe('Core: i18n', () => {
     })
   })
 
-  it('should respect the content of the localization files for http errors to connections', (done) => {
-    api.i18n.determineConnectionLocale = () => { return 'en' }
+  it('should respect the content of the localization files for http errors to connections or use defaults', (done) => {
+    api.i18n.determineConnectionLocale = () => { return 'test-env-en' }
     api.specHelper.getStaticFile('missing-file.html', (data) => {
-      expect(data.error).to.match(/That file is not found/)
+      expect(data.error).to.equal('actionhero.errors.fileNotFound')
 
-      api.i18n.determineConnectionLocale = () => { return 'es' }
+      api.i18n.determineConnectionLocale = () => { return 'test-env-es' }
       api.specHelper.getStaticFile('missing-file.html', (data) => {
         expect(data.error).to.match(/Ese archivo no se encuentra/)
         done()

--- a/test/core/i18n.js
+++ b/test/core/i18n.js
@@ -50,8 +50,8 @@ describe('Core: i18n', () => {
   })
 
   after((done) => {
-    // fs.unlinkSync(path.join(__dirname, '/../../locales/test-env-en.json'))
-    // fs.unlinkSync(path.join(__dirname, '/../../locales/test-env-es.json'))
+    fs.unlinkSync(path.join(__dirname, '/../../locales/test-env-en.json'))
+    fs.unlinkSync(path.join(__dirname, '/../../locales/test-env-es.json'))
     actionhero.stop(() => {
       done()
     })


### PR DESCRIPTION
- clarify the usage of i18n and `connection.localize` by converting all localizations to use mustache-style strings.  IE: `data.connection.localize(['hello {{name}}', {name: 'Evan'}])` rather than `data.connection.localize(['hello %s, evan])`
- [BREAKING CAHNGE] Stop localizing all internal and logging messages
  - this feature was rarely used and added complexity.  This also slowed down the logging of message from the server as it required 2 interpolation passes each time
  - convert all internal message interpolation into es6 interpolation, ie: `a log ${message}`.  Now that we required node v4+, this is OK
- [BREAKTING CHANGE] move all user-visible strings from actionhero into the locale file.  This creates a single file which can be used to modify ActionHero strings
  - All actionhero strings reside within an `actionhero` translation namespace: https://github.com/actionhero/actionhero/blob/mustache_i18n/locales/en.json
  - `locales/en.json` is now checked into the project
  - ensure this locale file is copied into a new project via `actionhero generate`
  - `welcomeMessage` and `goodbyeMessage` are removed from config into locale
- ensure that by default, calling either `api.i18n.localize` or `connection.localize` on an unknown string will not cause an error, and this string will be added to the locale file properly