### PR TITLE
server.connectionCustomMethods

### DIFF
--- a/initializers/connections.js
+++ b/initializers/connections.js
@@ -131,6 +131,14 @@ module.exports = {
         if (this[i] === undefined) { this[i] = connectionDefaults[i] }
       }
 
+      let connection = this
+      for (let name in api.servers.servers[connection.type].connectionCustomMethods) {
+        connection[name] = function () {
+          let args = [connection].concat(Array.from(arguments))
+          api.servers.servers[connection.type].connectionCustomMethods[name].apply(null, args)
+        }
+      }
+
       api.i18n.invokeConnectionLocale(this)
     }
 

--- a/initializers/connections.js
+++ b/initializers/connections.js
@@ -132,10 +132,13 @@ module.exports = {
       }
 
       let connection = this
-      for (let name in api.servers.servers[connection.type].connectionCustomMethods) {
-        connection[name] = function () {
-          let args = [connection].concat(Array.from(arguments))
-          api.servers.servers[connection.type].connectionCustomMethods[name].apply(null, args)
+      let server = api.servers.servers[connection.type]
+      if (server && server.connectionCustomMethods) {
+        for (let name in server.connectionCustomMethods) {
+          connection[name] = function () {
+            let args = [connection].concat(Array.from(arguments))
+            server.connectionCustomMethods[name].apply(null, args)
+          }
         }
       }
 

--- a/servers/web.js
+++ b/servers/web.js
@@ -236,6 +236,12 @@ const initialize = function (api, options, next) {
     // disconnect handlers
   }
 
+  server.connectionCustomMethods = {
+    setHeader: function (connection, key, value) {
+      connection.rawConnection.res.setHeader(key, value)
+    }
+  }
+
   // //////////
   // EVENTS //
   // //////////


### PR DESCRIPTION
This PR proxies the `setHeader` function from a http response object so that actions running on the web server can use `data.connection.setHeader` instead of `data.connection.rawConnection.res.setHeader`.

We also came up with a neat way for servers to apply custom methods to their connections.

Work done with @gcoonrod !

Fixes up https://github.com/actionhero/actionhero/pull/1053