### PR TITLE
fix race condition in websocket server

### DIFF
--- a/servers/websocket.js
+++ b/servers/websocket.js
@@ -220,6 +220,7 @@ const initialize = function (api, options, next) {
     const verb = data.event
     delete data.event
     connection.messageCount++
+    const messageCount = connection.messageCount
     connection.params = {}
     if (verb === 'action') {
       for (let v in data.params) {
@@ -244,10 +245,10 @@ const initialize = function (api, options, next) {
       connection.verbs(verb, words, (error, data) => {
         if (!error) {
           message = {status: 'OK', context: 'response', data: data}
-          server.sendMessage(connection, message)
+          server.sendMessage(connection, message, messageCount)
         } else {
           message = {status: error, context: 'response', data: data}
-          server.sendMessage(connection, message)
+          server.sendMessage(connection, message, messageCount)
         }
       })
     }

--- a/test/servers/websocket.js
+++ b/test/servers/websocket.js
@@ -118,6 +118,34 @@ describe('Server: Web Socket', () => {
     })
   })
 
+  it('properly responds with messageCount', (done) => {
+    let verbResponse = false
+    let actionResponse = false
+    let verbMsgCount = false
+    let actionMsgCount = false
+    clientA.roomAdd('defaultRoom', (response) => {
+      verbResponse = true
+      verbMsgCount = response.messageCount
+      if (actionResponse) {
+        expect(actionMsgCount).to.not.equal(verbMsgCount)
+        done()
+      }
+    })
+    clientA.action('sleepTest', {sleepDuration: 100}, (response) => {
+      actionResponse = true
+      actionMsgCount = response.messageCount
+      if (verbResponse) {
+        expect(verbMsgCount).to.not.equal(actionResponse)
+        done()
+      }
+    })
+    setTimeout(() => {
+      if (!actionResponse && !verbResponse) {
+        done('Not all responses received')
+      }
+    }, 2000)
+  })
+
   it('will limit how many simultaneous connections I can have', (done) => {
     var responses = []
     clientA.action('sleepTest', {sleepDuration: 100}, (response) => { responses.push(response) })

--- a/test/servers/websocket.js
+++ b/test/servers/websocket.js
@@ -119,10 +119,10 @@ describe('Server: Web Socket', () => {
   })
 
   it('properly responds with messageCount', (done) => {
-    let verbResponse = false
-    let actionResponse = false
-    let verbMsgCount = false
-    let actionMsgCount = false
+    var verbResponse = false
+    var actionResponse = false
+    var verbMsgCount = false
+    var actionMsgCount = false
     clientA.roomAdd('defaultRoom', (response) => {
       verbResponse = true
       verbMsgCount = response.messageCount


### PR DESCRIPTION
When you connect to actionhero via the client over websocket and send 2 parallel requests .... one action request and one "verb" (like 'roomAdd', 'roomLeave' or 'roomView') in the following constellation:

1. send verb roomLeave request
-> connection.messageNumber++ (now 1)
2. send action request (action takes a little longer ~500ms) 
-> connection.messageNumber++ (now 2)
3. answer received from roomLeave request (messageCount send back from actionhero: 2(!!!))
4. answer received fromaction request (messageCount send back from actionhero: 2(!!!))

When the verb is answered, no "messageCount" is given to server.sendMessage ... so the implementation takes the current connection.messageCount number to answer the request.

this pr fixes this problem with creating a temporary variable for the message count and giving it to the server.sendMessage function