### PR TITLE
Properly release all handlers; Support mocha 4.0

### DIFF
--- a/initializers/cache.js
+++ b/initializers/cache.js
@@ -25,6 +25,8 @@ class Cache extends ActionHero.Initializer {
   }
 
   initialize () {
+    if (api.config.redis.enabled === false) { return }
+
     const redis = api.redis.clients.client
 
     api.cache = {

--- a/initializers/chatRoom.js
+++ b/initializers/chatRoom.js
@@ -79,6 +79,8 @@ class ChatRoom extends ActionHero.Initializer {
   }
 
   initialize () {
+    if (api.config.redis.enabled === false) { return }
+
     api.chatRoom = {
       middleware: {},
       globalMiddleware: [],
@@ -440,6 +442,8 @@ class ChatRoom extends ActionHero.Initializer {
   }
 
   async start () {
+    if (api.config.redis.enabled === false) { return }
+
     api.redis.subscriptionHandlers.chat = (message) => {
       if (api.chatRoom) { api.chatRoom.incomingMessage(message) }
     }

--- a/initializers/config.js
+++ b/initializers/config.js
@@ -48,7 +48,7 @@ module.exports = class Config extends ActionHero.Initializer {
       api.watchedFiles.forEach(({file: watchedFile}) => { if (watchedFile === file) { found = true } })
 
       if (api.config.general.developmentMode === true && found === false) {
-        const watcher = fs.watch(file, (eventType) => {
+        const watcher = fs.watch(file, {persistent: false}, (eventType) => {
           if (
             api.running === true &&
             api.config.general.developmentMode === true &&

--- a/initializers/resque.js
+++ b/initializers/resque.js
@@ -25,7 +25,7 @@ module.exports = class Resque extends ActionHero.Initializer {
   }
 
   initialize () {
-    if (api.config.redis === false) { return }
+    if (api.config.redis.enabled === false) { return }
 
     const resqueOverrides = api.config.tasks.resque_overrides
 

--- a/initializers/specHelper.js
+++ b/initializers/specHelper.js
@@ -231,10 +231,17 @@ module.exports = class SpecHelper extends ActionHero.Initializer {
         queues: api.config.tasks.queues || ['default']
       }, api.tasks.jobs)
 
-      await worker.connect()
-      let result = await worker.performInline(taskName, params)
-      await worker.end()
-      return result
+      try {
+        await worker.connect()
+        let result = await worker.performInline(taskName, params)
+        await worker.end()
+        return result
+      } catch (error) {
+        try {
+          worker.end()
+        } catch (error) {}
+        throw error
+      }
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "actionhero",
-  "version": "18.0.0-beta.1",
+  "version": "18.0.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -659,9 +659,9 @@
       }
     },
     "diff": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
       "dev": true
     },
     "dirty-chai": {
@@ -1401,17 +1401,28 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-      "dev": true
-    },
     "growl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
-      "dev": true
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.2.tgz",
+      "integrity": "sha512-nidsnaoWVZIBLwA3sUIp3dA2DP2rT3dwEqINVacQ0+rZmc6UOwj2D729HTEjQYUKb+3wL9MeDbxpZtEiEJoUHQ==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-node": "5.2.0"
+      },
+      "dependencies": {
+        "eslint-plugin-node": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-5.2.0.tgz",
+          "integrity": "sha512-N9FLFwknT5LhRhjz1lmHguNss/MCwkrLCS4CjqqTZZTJaUhLRfDNK3zxSHL/Il3Aa0Mw+xY3T1gtsJrUNoJy8Q==",
+          "dev": true,
+          "requires": {
+            "ignore": "3.3.5",
+            "minimatch": "3.0.4",
+            "resolve": "1.4.0",
+            "semver": "5.3.0"
+          }
+        }
+      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -1462,9 +1473,9 @@
       }
     },
     "has-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
       "dev": true
     },
     "hawk": {
@@ -1833,12 +1844,6 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
-    "json3": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
-      "dev": true
-    },
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
@@ -1932,53 +1937,6 @@
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
       "dev": true
     },
-    "lodash._baseassign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true,
-      "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
-      },
-      "dependencies": {
-        "lodash.keys": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-          "dev": true,
-          "requires": {
-            "lodash._getnative": "3.9.1",
-            "lodash.isarguments": "3.1.0",
-            "lodash.isarray": "3.0.4"
-          }
-        }
-      }
-    },
-    "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-      "dev": true
-    },
-    "lodash._basecreate": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
-      "dev": true
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "dev": true
-    },
-    "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-      "dev": true
-    },
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
@@ -2005,17 +1963,6 @@
       "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
       "dev": true
     },
-    "lodash.create": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true,
-      "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
-      }
-    },
     "lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -2035,18 +1982,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
-    },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-      "dev": true
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
     },
     "lodash.isempty": {
       "version": "4.4.0",
@@ -2188,47 +2123,36 @@
       }
     },
     "mocha": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.0.tgz",
+      "integrity": "sha512-83e2QQWKbcBiPb1TuS80i4DxkpqQoOC9Y0TxOuML8NkzZWUkJJqWHAslhUS7x5nQcYMqnMwZDp5v3ABzV+ivCA==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
-        "commander": "2.9.0",
-        "debug": "2.6.8",
-        "diff": "3.2.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
         "escape-string-regexp": "1.0.5",
-        "glob": "7.1.1",
-        "growl": "1.9.2",
+        "glob": "7.1.2",
+        "growl": "1.10.2",
         "he": "1.1.1",
-        "json3": "3.3.2",
-        "lodash.create": "3.1.1",
         "mkdirp": "0.5.1",
-        "supports-color": "3.1.2"
+        "supports-color": "4.4.0"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          }
-        },
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
         "glob": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -2264,9 +2188,9 @@
       "dev": true
     },
     "node-resque": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/node-resque/-/node-resque-5.0.1.tgz",
-      "integrity": "sha512-ByGoHTE5TXsJme3bc1lkVehLtJ3KnthwiAHkYtXuBb2gXnmfOGomnwli2Uc1xGBf8gNQ9384ZpfaOQBrU3vMBg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/node-resque/-/node-resque-5.0.2.tgz",
+      "integrity": "sha512-1NeyKY3sME64naqzqxzxXG7QTgVhr58kcdfy36o1QBVLX6pcb2aHeU7ie7Lm7nyRj9FaK2zQQ1lP/lg2/VJbUQ==",
       "requires": {
         "ioredis": "3.1.4"
       }
@@ -2990,12 +2914,12 @@
       "dev": true
     },
     "supports-color": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-      "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
       "dev": true,
       "requires": {
-        "has-flag": "1.0.0"
+        "has-flag": "2.0.0"
       }
     },
     "table": {
@@ -3135,9 +3059,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.1.2.tgz",
-      "integrity": "sha512-kKJ8zg7Ivw3DG9Ytgp4+iiSHq3HaHjEQMvyT2x2Bs8kSUwVemj6bPGFp6YWL81f5NAIOLVUKPxBSvqLRGXMpdw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.1.3.tgz",
+      "integrity": "sha512-5ZUOgufCHjN2mBBLfz63UtWTP6va2sSzBpNCM+/iqI6RnPzEhANmB0EKiKBYdQbc3v7KeomXJ2DJx0Xq9gvUvA==",
       "requires": {
         "commander": "2.11.0",
         "source-map": "0.5.7"
@@ -3238,9 +3162,9 @@
       }
     },
     "winston": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
-      "integrity": "sha1-C0hCDZeMAYBM8CMLZIhhWYIloRk=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
+      "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
       "requires": {
         "async": "1.0.0",
         "colors": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -39,13 +39,13 @@
     "ioredis": "^3.1.4",
     "is-running": "^2.0.1",
     "mime": "^2.0.3",
-    "node-resque": "^5.0.1",
+    "node-resque": "^5.0.2",
     "optimist": "^0.6.1",
     "primus": "^7.1.0",
     "qs": "^6.5.1",
-    "uglify-js": "^3.1.2",
+    "uglify-js": "^3.1.3",
     "uuid": "^3.1.0",
-    "winston": "^2.0.0",
+    "winston": "^2.4.0",
     "ws": "^3.1.0"
   },
   "devDependencies": {
@@ -54,7 +54,7 @@
     "dirty-chai": "^2.0.0",
     "docdash-actionhero": "0.0.3",
     "jsdoc": "^3.5.5",
-    "mocha": "^3.5.3",
+    "mocha": "^4.0.0",
     "request": "^2.83.0",
     "request-promise-native": "^1.0.5",
     "standard": "^10.0.3"

--- a/servers/websocket.js
+++ b/servers/websocket.js
@@ -65,6 +65,8 @@ module.exports = class WebSocketServer extends ActionHero.Server {
     if (this.config.destroyClientsOnShutdown === true) {
       this.connections().forEach((connection) => { connection.destroy() })
     }
+
+    this.server.destroy()
   }
 
   sendMessage (connection, message, messageCount) {


### PR DESCRIPTION
Update all packages to the latest versions.

Properly disable `chat`, `cache` and `resque` when `redis` is disabled via config.

Mocha 4.0 has some changes, including that it won't exit the process when the test  suite is done (https://boneskull.com/mocha-v4-nears-release/#mochawontforceexit).  This exposed a few things ActionHero was doing which didn't 'shut down' nicely:
- We were not releasing file change watchers (developer mode) properly when shutting down
- We were not disconnecting the websocket server listeners properly when shutting down