### PR TITLE
Run CLI commands found in plugins `{plugin}/bin` directory

### DIFF
--- a/bin/actionhero
+++ b/bin/actionhero
@@ -5,8 +5,7 @@ const fs = require('fs')
 const path = require('path')
 const optimist = require('optimist')
 const spawn = require('child_process').spawn
-const ActionHero = require(path.join(__dirname, '..', 'index.js'))
-const api = ActionHero.api
+const {api, Process} = require(path.join(__dirname, '..', 'index.js'))
 const actionheroRoot = path.normalize(path.join(__dirname, '..'))
 let projectRoot
 
@@ -73,21 +72,38 @@ const handleGenerate = async () => {
 
 const handleMethod = async () => {
   try {
-    const actionHeroProcess = new ActionHero.Process()
-    await actionHeroProcess.initialize()
+    const actionHeroProcess = new Process()
+    let configChanges = {}
+
+    if (process.env.configChanges) { configChanges = JSON.parse(process.env.configChanges) }
+    if (optimist.argv.configChanges) { configChanges = JSON.parse(optimist.argv.configChanges) }
+
+    await actionHeroProcess.initialize({configChanges})
     if (!api.projectRoot) { api.projectRoot = projectRoot }
     if (!api.actionheroRoot) { api.actionheroRoot = actionheroRoot }
     api._context = actionHeroProcess
     let RunnerClass
 
     let p = path.join(__dirname, 'methods', commands.join(path.sep) + '.js')
-    if (fs.existsSync(p) && api.config.general.cliIncludeInternal === true) {
+    if (fs.existsSync(p) && api.config.general.cliIncludeInternal !== false) {
       RunnerClass = require(p)
-    } else {
-      api.config.general.paths.cli.forEach((cliPaths) => {
-        p = path.join(cliPaths, commands.join(path.sep) + '.js')
+    }
+
+    if (!RunnerClass) {
+      api.config.general.paths.cli.forEach((cliPath) => {
+        p = path.join(cliPath, commands.join(path.sep) + '.js')
         if (fs.existsSync(p)) { RunnerClass = require(p) }
       })
+    }
+
+    if (!RunnerClass) {
+      for (let pluginName in api.config.plugins) {
+        if (api.config.plugins[pluginName].cli !== false) {
+          let pluginPath = api.config.plugins[pluginName].path
+          p = path.join(pluginPath, 'bin', commands.join(path.sep) + '.js')
+          if (fs.existsSync(p)) { RunnerClass = require(p) }
+        }
+      }
     }
 
     if (!RunnerClass) {
@@ -95,9 +111,9 @@ const handleMethod = async () => {
       console.error('run `actionhero help` to learn more')
       setTimeout(process.exit, 500, 1)
     } else {
-      console.log('--------------------------------------')
+      console.log('₋₋₋₋₋₋₋₋₋₋₋₋₋₋₋₋₋₋₋₋₋₋₋₋₋₋₋₋₋₋₋₋₋₋₋₋₋₋')
       console.log(`ACTIONHERO COMMAND >> ${commands.join(' ')}`)
-      console.log('--------------------------------------')
+      console.log('⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻')
 
       if (optimist.argv.daemon) {
         let newArgs = process.argv.splice(2)
@@ -113,7 +129,7 @@ const handleMethod = async () => {
         const runner = new RunnerClass()
         let params = formatParams(runner)
         let toStop = await runner.run({params: params})
-        if (toStop) {
+        if (toStop || toStop === null || toStop === undefined) {
           setTimeout(process.exit, 500, 0)
         }
       }

--- a/bin/methods/generate/plugin.js
+++ b/bin/methods/generate/plugin.js
@@ -28,6 +28,7 @@ module.exports = class GeneratePlugin extends ActionHero.CLI {
       'initializers',
       'servers',
       'config',
+      'bin',
       'public'
     ].forEach((type) => {
       try {

--- a/bin/methods/help.js
+++ b/bin/methods/help.js
@@ -49,7 +49,9 @@ module.exports = class Help extends ActionHero.CLI {
 
     let methodNames = Object.keys(methods).sort()
 
-    console.log('ActionHero - A multi-transport node.js API Server with integrated cluster capabilities and delayed tasks\r\n')
+    console.log('ActionHero - The reusable, scalable, and quick node.js API server for stateless and stateful applications')
+    console.log('Learn more @ www.actionherojs.com')
+    console.log('')
     console.log('CLI Commands:\r\n')
     methodNames.forEach((methodName) => {
       console.log(`* ${methodName}`)

--- a/bin/methods/help.js
+++ b/bin/methods/help.js
@@ -16,8 +16,25 @@ module.exports = class Help extends ActionHero.CLI {
     let files = []
     let methods = {}
 
-    glob.sync(path.join(api.actionheroRoot, 'bin', 'methods', '**', '*.js')).forEach((f) => { files.push(f) })
-    glob.sync(path.join(api.projectRoot + 'bin', '**', '*.js')).forEach((f) => { files.push(f) })
+    // CLI commands included with ActionHero
+    if (api.config.general.cliIncludeInternal !== false) {
+      glob.sync(path.join(api.actionheroRoot, 'bin', 'methods', '**', '*.js')).forEach((f) => { files.push(f) })
+    }
+
+    // CLI commands included in this project
+    api.config.general.paths.cli.forEach((cliPath) => {
+      glob.sync(path.join(cliPath, '**', '*.js')).forEach((f) => { files.push(f) })
+    })
+
+    // CLI commands from plugins
+    Object.keys(api.config.plugins).forEach((pluginName) => {
+      let plugin = api.config.plugins[pluginName]
+      if (plugin.cli !== false) {
+        glob.sync(path.join(plugin.path, 'bin', '**', '*.js')).forEach((f) => { files.push(f) })
+      }
+    })
+
+    files = api.utils.arrayUniqueify(files)
 
     files.forEach((f) => {
       try {
@@ -33,33 +50,46 @@ module.exports = class Help extends ActionHero.CLI {
     let methodNames = Object.keys(methods).sort()
 
     console.log('ActionHero - A multi-transport node.js API Server with integrated cluster capabilities and delayed tasks\r\n')
-    console.log('Binary options:\r\n')
+    console.log('CLI Commands:\r\n')
     methodNames.forEach((methodName) => {
       console.log(`* ${methodName}`)
     })
 
-    console.log('\r\nDescriptions:')
     methodNames.forEach((methodName) => {
       let m = methods[methodName]
-      console.log(`\r\n* ${m.name}`)
-      console.log(`  description: ${m.description}`)
+      this.highlightWord(`actionhero ${m.name}`)
+      console.log(`description: ${m.description}`)
 
       if (m.example) {
-        console.log(`  example: ${m.example}`)
+        console.log(`example: ${m.example}`)
       }
 
       if (!m.inputs) { m.inputs = {} }
       if (Object.keys(m.inputs).length > 0) {
-        console.log(`  inputs:`)
+        console.log(`inputs:`)
         Object.keys(m.inputs).forEach((inputName) => {
           let i = m.inputs[inputName]
-          console.log(`    [${inputName}] ${(i.required ? '' : '(optional)')}`)
-          if (i.note) { console.log(`      note: ${i.note}`) }
-          if (i.default) { console.log(`      default: ${i.default}`) }
+          console.log(`  [${inputName}] ${(i.required ? '' : '(optional)')}`)
+          if (i.note) { console.log(`    note: ${i.note}`) }
+          if (i.default) { console.log(`    default: ${i.default}`) }
         })
       }
     })
 
+    console.log('')
+
     return true
+  }
+
+  highlightWord (word) {
+    let lines
+    console.log('\r\n')
+    lines = ''
+    for (let i = 0; i < word.length; i++) { lines += '₋' }
+    console.log(lines)
+    console.log(word)
+    lines = ''
+    for (let i = 0; i < word.length; i++) { lines += '⁻' }
+    console.log(lines)
   }
 }

--- a/classes/cli.js
+++ b/classes/cli.js
@@ -25,7 +25,8 @@ module.exports = class MyCLICommand extends CLI {
   }
 
   async run ({params}) {
-    return api.cache.dumpWrite(params.file)
+    await api.cache.dumpWrite(params.file)
+    return true
   }
 }
    */
@@ -38,11 +39,14 @@ module.exports = class MyCLICommand extends CLI {
   }
 
   /**
+   * The main "do something" method for this CLI command.  It is an `async` method.
+   * If error is thrown in this method, it will be logged to STDERR, and the process will terminate with a non-0 exit code.
+   *
    * @function run
    * @async
    * @memberof ActionHero.CLI
    * @param  {Object}  data The data about this instance of the CLI run, specifically params.
-   * @description The main "do something" method for this CLI command.  It can be `async`.  If error is thrown in this method, it will be logged to STDERR, and the process will terminate with a non-0 exit code.
+   * @return {Promise<Boolean>} The return value of `run` is `toShutdown` (boolean).  If you return true, the CLI process will exit if when the method returns, false will keep running.
    */
 
   coreProperties () {

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -16,7 +16,8 @@ exports['default'] = {
         tasks: true,
         initializers: true,
         servers: true,
-        public: true
+        public: true,
+        cli: true
       }
     }
     */

--- a/test/core/cli.js
+++ b/test/core/cli.js
@@ -63,10 +63,10 @@ const sleep = async (timeout) => { await promisify(setTimeout)(timeout) }
 
 describe('Core: CLI', () => {
   if (process.platform === 'win32') {
-    console.log('*** CANNOT RUN BINARY TESTS ON WINDOWS.  Sorry. ***')
+    console.log('*** CANNOT RUN CLI TESTS ON WINDOWS.  Sorry. ***')
   } else {
     before(async () => {
-      if (process.env.SKIP_BINARY_TEST_SETUP === 'true') { return }
+      if (process.env.SKIP_CLI_TEST_SETUP === 'true') { return }
 
       let sourcePackage = path.normalize(path.join(__dirname, '/../../bin/templates/package.json'))
       AHPath = path.normalize(path.join(__dirname, '/../..'))
@@ -136,7 +136,7 @@ describe('Core: CLI', () => {
     it('can call the help command', async () => {
       let {stdout} = await doCommand(`${binary} help`)
       expect(stdout).to.match(/actionhero start cluster/)
-      expect(stdout).to.match(/Binary options:/)
+      expect(stdout).to.match(/The reusable, scalable, and quick node.js API server for stateless and stateful applications/)
       expect(stdout).to.match(/actionhero generate server/)
     })
 

--- a/test/core/plugins.js
+++ b/test/core/plugins.js
@@ -6,6 +6,8 @@ const expect = chai.expect
 chai.use(dirtyChai)
 
 const path = require('path')
+const {promisify} = require('util')
+const exec = require('child_process').exec
 const ActionHero = require(path.join(__dirname, '/../../index.js'))
 const actionhero = new ActionHero.Process()
 let api
@@ -48,6 +50,19 @@ describe('Core: Plugins', () => {
       expect(file.content).to.equal('<h1>PLUGIN!<h1>\n')
       expect(file.mime).to.equal('text/html')
     })
+
+    it('can load CLI command from a plugin', async () => {
+      let env = process.env
+      env.configChanges = JSON.stringify(configChanges)
+
+      let {stdout: helpResponse, stderr: error1} = await promisify(exec)('./bin/actionhero help', {env})
+      expect(error1).to.equal('')
+      expect(helpResponse).to.contain('hello')
+
+      let {stdout: helloResponse, stderr: error2} = await promisify(exec)('./bin/actionhero hello', {env})
+      expect(error2).to.equal('')
+      expect(helloResponse).to.contain('hello')
+    })
   })
 
   describe('with plugin sections ignored', () => {
@@ -60,7 +75,8 @@ describe('Core: Plugins', () => {
             tasks: false,
             servers: false,
             initializers: false,
-            public: false
+            public: false,
+            cli: false
           }
         }
       }
@@ -90,6 +106,22 @@ describe('Core: Plugins', () => {
       let file = await api.specHelper.getStaticFile('plugin.html')
       expect(file.error).to.match(/file is not found/)
     })
+
+    it('will not load CLI command from an un-loaded plugin', async () => {
+      let env = process.env
+      env.configChanges = JSON.stringify(configChanges)
+
+      let {stdout: helpResponse, stderr: error1} = await promisify(exec)('./bin/actionhero help', {env})
+      expect(error1).to.equal('')
+      expect(helpResponse).to.not.contain('hello')
+
+      try {
+        await promisify(exec)('./bin/actionhero hello', {env})
+        throw new Error('should not get here')
+      } catch (error) {
+        expect(error).to.match(/`hello` is not a method I can perform/)
+      }
+    })
   })
 
   describe('without plugin', () => {
@@ -115,6 +147,19 @@ describe('Core: Plugins', () => {
     it('will not serve static files from an un-loaded plugin', async () => {
       let file = await api.specHelper.getStaticFile('plugin.html')
       expect(file.error).to.match(/file is not found/)
+    })
+
+    it('will not load CLI command from an un-loaded plugin', async () => {
+      let {stdout: helpResponse, stderr: error1} = await promisify(exec)('./bin/actionhero help')
+      expect(error1).to.equal('')
+      expect(helpResponse).to.not.contain('hello')
+
+      try {
+        await promisify(exec)('./bin/actionhero hello')
+        throw new Error('should not get here')
+      } catch (error) {
+        expect(error).to.match(/`hello` is not a method I can perform/)
+      }
     })
   })
 })

--- a/test/core/plugins.js
+++ b/test/core/plugins.js
@@ -52,7 +52,7 @@ describe('Core: Plugins', () => {
     })
 
     it('can load CLI command from a plugin', async () => {
-      let env = process.env
+      let env = Object.assign({}, process.env)
       env.configChanges = JSON.stringify(configChanges)
 
       let {stdout: helpResponse, stderr: error1} = await promisify(exec)('./bin/actionhero help', {env})
@@ -108,7 +108,7 @@ describe('Core: Plugins', () => {
     })
 
     it('will not load CLI command from an un-loaded plugin', async () => {
-      let env = process.env
+      let env = Object.assign({}, process.env)
       env.configChanges = JSON.stringify(configChanges)
 
       let {stdout: helpResponse, stderr: error1} = await promisify(exec)('./bin/actionhero help', {env})

--- a/test/testPlugin/bin/hello.js
+++ b/test/testPlugin/bin/hello.js
@@ -1,0 +1,14 @@
+const {CLI} = require('./../../../index.js')
+
+module.exports = class Version extends CLI {
+  constructor () {
+    super()
+    this.name = 'hello'
+    this.description = 'I say hello'
+  }
+
+  run () {
+    console.log('hello')
+    return true
+  }
+}

--- a/tutorials/plugins.md
+++ b/tutorials/plugins.md
@@ -19,6 +19,7 @@ Plugins are loaded after all local ActionHero project files, but initializers fo
 | - initializers
 | - config
 | - public
+| - cli
 |
 | - package.json
 ```
@@ -45,6 +46,7 @@ return {
     tasks: true,
     initializers: true,
     servers: true,
+    cli: true,
     public: true
   }
 }

--- a/tutorials/running-actionhero.md
+++ b/tutorials/running-actionhero.md
@@ -137,7 +137,7 @@ If you installed ActionHero globally (`npm install actionhero -g`) you should ha
 
 If you installed ActionHero locally, you can add a reference to your path (OSX and Linux): `export PATH=$PATH:node_modules/.bin` to be able to use simpler commands, IE `actionhero start`. On windows this can be done by running `set PATH=%PATH%;%cd%\node_modules\.bin` at command prompt (not powershell).
 
-Newer versions of NPM (v4+) allow you to also use the `npx` command, ie: `npx actionhero start cluster --workers=2`
+Newer versions of NPM (v4+) allow you to also use the `npx` command, ie: `npx actionhero start cluster --workers=2`, which is a simple way to get to the ActionHero binary from the top-level of your project. 
 
 ## Environments and Config
 
@@ -148,6 +148,8 @@ The load order of configs is:
 * default values in `/config`
 * environment-specific values in `/config`
 * options passed in to boot with `actionhero.start({configChanges: configChanges})`
+
+You can `{configChanges: {}}` to a new ActionHero.Process' `start` or `initialize` methods.  This can be helpful when creating tests. When using CLI commands, you can also set `process.env.configChanges` or pass `--configChanges` on the command line. In these cases, `configChanges` should be stringified JSON.
 
 ```js
 // from ./config/namespace.js
@@ -186,7 +188,7 @@ const sleep = (time) => {
   })
 }
 
-const api = await actionhero.start()
+const api = await actionhero.start({configChanges})
 
 api.log(" >> Boot Successful!")
 await sleep()


### PR DESCRIPTION
Solves https://github.com/actionhero/actionhero/issues/1129.

Also allows for `configChanges` to be passed to ActionHero CLI commands via `--configChanges {stringified JSON}` or via ENV.  This is handy when creating tests for CLI commands:

```js
it('can load CLI command from a plugin', async () => {
  let env = process.env
  env.configChanges = JSON.stringify(configChanges)

  let {stdout: helpResponse, stderr: error1} = await promisify(exec)('./bin/actionhero help', {env})
  expect(error1).to.equal('')
  expect(helpResponse).to.contain('hello')

  let {stdout: helloResponse, stderr: error2} = await promisify(exec)('./bin/actionhero hello', {env})
  expect(error2).to.equal('')
  expect(helloResponse).to.contain('hello')
})
```

Also fixed a a bug where `api.config.general.paths.cli` was not consulted when reading HELP for CLI commands in a local project