### PR TITLE
Fix `this` in tasks

### DIFF
--- a/classes/task.js
+++ b/classes/task.js
@@ -39,6 +39,7 @@ module.exports = class SayHello extends Task {
   /**
    * The main "do something" method for this task.  It can be `async`.  Anything returned from this metod will be logged.
    * If error is thrown in this method, it will be logged & caught.  Using middleware, you can decide to re-run the task on failure.
+   * `this` is a Task instance itself now.
    * Instance of a node-resque worker can be accessed at this.worker within a Task's run method. This means you can inspect `this.worker.job` and set `this.worker.result` explicitly if your Task does not return a value.
    *
    * @function run

--- a/classes/task.js
+++ b/classes/task.js
@@ -37,11 +37,14 @@ module.exports = class SayHello extends Task {
   }
 
   /**
+   * The main "do something" method for this task.  It can be `async`.  Anything returned from this metod will be logged.
+   * If error is thrown in this method, it will be logged & caught.  Using middleware, you can decide to re-run the task on failure.
+   * `this` within a Task's run method is an instance of a node-resque worker.  This means you can inpsect `this.job` and set `this.result` expliclity if your Task does not return a value.
+   *
    * @function run
    * @async
    * @memberof ActionHero.Task
    * @param  {Object}  data The data about this instance of the task, specifically params.
-   * @description The main "do something" method for this task.  It can be `async`.  Anything returned from this metod will be logged.  If error is thrown in this method, it will be logged & caught.  Using middleware, you can decide to re-run the task on failure.
    */
 
   coreProperties () {

--- a/classes/task.js
+++ b/classes/task.js
@@ -39,7 +39,7 @@ module.exports = class SayHello extends Task {
   /**
    * The main "do something" method for this task.  It can be `async`.  Anything returned from this metod will be logged.
    * If error is thrown in this method, it will be logged & caught.  Using middleware, you can decide to re-run the task on failure.
-   * `this` within a Task's run method is an instance of a node-resque worker.  This means you can inpsect `this.job` and set `this.result` expliclity if your Task does not return a value.
+   * Instance of a node-resque worker can be accessed at this.worker within a Task's run method. This means you can inspect `this.worker.job` and set `this.worker.result` explicitly if your Task does not return a value.
    *
    * @function run
    * @async

--- a/classes/task.js
+++ b/classes/task.js
@@ -23,7 +23,7 @@ module.exports = class SayHello extends Task {
    this.frequency = (60 * 1000)
  }
 
- async run (data) {
+ async run (data, worker) {
    api.log('Hello!')
  }
 }
@@ -40,12 +40,12 @@ module.exports = class SayHello extends Task {
    * The main "do something" method for this task.  It can be `async`.  Anything returned from this metod will be logged.
    * If error is thrown in this method, it will be logged & caught.  Using middleware, you can decide to re-run the task on failure.
    * `this` is a Task instance itself now.
-   * Instance of a node-resque worker can be accessed at this.worker within a Task's run method. This means you can inspect `this.worker.job` and set `this.worker.result` explicitly if your Task does not return a value.
    *
    * @function run
    * @async
    * @memberof ActionHero.Task
    * @param  {Object}  data The data about this instance of the task, specifically params.
+   * @param  {Object}  worker Instance of a node-resque worker. You can inspect `worker.job` and set `worker.result` explicitly if your Task does not return a value.
    */
 
   coreProperties () {

--- a/initializers/actions.js
+++ b/initializers/actions.js
@@ -15,6 +15,7 @@ const api = ActionHero.api
 /**
  * Middleware definition for Actions
  *
+ * @async
  * @typedef {Object} ActionHero~ActionMiddleware
  * @property {string} name - Unique name for the middleware.
  * @property {Boolean} global - Is this middleware applied to all actions?

--- a/initializers/chatRoom.js
+++ b/initializers/chatRoom.js
@@ -23,6 +23,7 @@ const api = ActionHero.api
 /**
  * Middleware definition for processing chat events.  Can be of the
  *
+ * @async
  * @typedef {Object} ActionHero~ChatMiddleware
  * @property {string} name - Unique name for the middleware.
  * @property {Number} priority - Module load order. Defaults to `api.config.general.defaultMiddlewarePriority`.

--- a/initializers/tasks.js
+++ b/initializers/tasks.js
@@ -18,6 +18,7 @@ const api = ActionHero.api
 /**
  * Middleware definition for Actions
  *
+ * @async
  * @typedef {Object} ActionHero~TaskMiddleware
  * @property {string} name - Unique name for the middleware.
  * @property {Boolean} global - Is this middleware applied to all tasks?

--- a/initializers/tasks.js
+++ b/initializers/tasks.js
@@ -146,6 +146,7 @@ module.exports = class Tasks extends ActionHero.Initializer {
         pluginOptions: pluginOptions,
         perform: async function () {
           let combinedArgs = [].concat(Array.prototype.slice.call(arguments))
+          task.worker = this
           let response = await task.run.apply(task, combinedArgs)
           await api.tasks.enqueueRecurrentTask(taskName)
           return response

--- a/initializers/tasks.js
+++ b/initializers/tasks.js
@@ -146,7 +146,7 @@ module.exports = class Tasks extends ActionHero.Initializer {
         pluginOptions: pluginOptions,
         perform: async function () {
           let combinedArgs = [].concat(Array.prototype.slice.call(arguments))
-          task.worker = this
+          combinedArgs.push(this)
           let response = await task.run.apply(task, combinedArgs)
           await api.tasks.enqueueRecurrentTask(taskName)
           return response

--- a/initializers/tasks.js
+++ b/initializers/tasks.js
@@ -146,7 +146,7 @@ module.exports = class Tasks extends ActionHero.Initializer {
         pluginOptions: pluginOptions,
         perform: async function () {
           let combinedArgs = [].concat(Array.prototype.slice.call(arguments))
-          let response = await api.tasks.tasks[taskName].run.apply(this, combinedArgs)
+          let response = await task.run.apply(task, combinedArgs)
           await api.tasks.enqueueRecurrentTask(taskName)
           return response
         }

--- a/test/core/tasks.js
+++ b/test/core/tasks.js
@@ -171,6 +171,36 @@ describe('Core: Tasks', () => {
     expect(taskOutput[0]).to.equal('theWord')
   })
 
+  it('can call task methods inside the run', async () => {
+    class TaskWithMethod extends ActionHero.Task {
+      constructor () {
+        super()
+        this.name = 'taskWithMethod'
+        this.description = 'task with additional methods to execute in run'
+        this.queue = queue
+      }
+      async stepOne () {
+        await sleep(100)
+        taskOutput.push('one')
+      }
+      stepTwo () {
+        taskOutput.push('two')
+      }
+      async run () {
+        await this.stepOne()
+        this.stepTwo()
+        taskOutput.push('tree')
+      }
+    }
+    api.tasks.tasks.taskWithMethod = new TaskWithMethod()
+    api.tasks.jobs.taskWithMethod = api.tasks.jobWrapper('taskWithMethod')
+    await api.specHelper.runFullTask('taskWithMethod', {})
+    expect(taskOutput).to.have.lengthOf(3)
+    expect(taskOutput[0]).to.equal('one')
+    expect(taskOutput[1]).to.equal('two')
+    expect(taskOutput[2]).to.equal('tree')
+  })
+
   it('no delayed tasks should be scheduled', async () => {
     let timestamps = await api.resque.queue.scheduledAt(queue, 'periodicTask', {})
     expect(timestamps).to.have.length(0)

--- a/test/core/tasks.js
+++ b/test/core/tasks.js
@@ -336,7 +336,7 @@ describe('Core: Tasks', () => {
           middleware: ['test-middleware'],
           run: function (params) {
             expect(params.test).to.equal(true)
-            let result = this.result
+            let result = this.worker.result
             result.run = true
             return result
           }

--- a/test/core/tasks.js
+++ b/test/core/tasks.js
@@ -281,7 +281,7 @@ describe('Core: Tasks', () => {
           queue: 'default',
           frequency: 0,
           middleware: ['test-middleware'],
-          run: (api, params) => {
+          run: (params, worker) => {
             throw new Error('Should never get here')
           }
         }
@@ -334,9 +334,9 @@ describe('Core: Tasks', () => {
           queue: 'default',
           frequency: 0,
           middleware: ['test-middleware'],
-          run: function (params) {
+          run: function (params, worker) {
             expect(params.test).to.equal(true)
-            let result = this.worker.result
+            let result = worker.result
             result.run = true
             return result
           }


### PR DESCRIPTION
Update `this` context inside `run` method to the task class instance itself.

It allows to call others task instance methods inside `run`method through `this`.

```js

module.exports = class SomeTask extends ActionHero.Task {
  constructor () {
    super()
    this.name = 'someTask'
    this.description = '...'
    this.frequency = 0
    this.queue = 'default'
    this.middleware = []
  }

  async stepOne (params) {
    ...
  }

  async stepTwo (params) {
    ...
  }

  async run (params) {
    let resOne = await this.stepOne()
    let resTwo = await this.stepTwo()
    ...
  }
}

```