### PR TITLE
specHelper redis connection

### DIFF
--- a/initializers/specHelper.js
+++ b/initializers/specHelper.js
@@ -228,7 +228,9 @@ module.exports = class SpecHelper extends ActionHero.Initializer {
      */
     api.specHelper.runFullTask = async (taskName, params) => {
       const worker = new NodeResque.Worker({
-        connection: api.redis.clients.tasks,
+        connection: {
+          redis: api.redis.clients.tasks
+        },
         queues: api.config.tasks.queues || ['default']
       }, api.tasks.jobs)
 


### PR DESCRIPTION
This is a fix for problem running unit-tests with non-standard redis configuration. E.g.

```sh
REDIS_HOST=192.168.99.100 npm test -- test/core/tasks.js
```

It tries to reconnect with default redis parameters. See `node-resque/lib/connection`.