### PR TITLE
Validators returning false now emit a generic error.

### DIFF
--- a/actions/validationTest.js
+++ b/actions/validationTest.js
@@ -1,0 +1,28 @@
+'use strict'
+const {Action} = require('./../index.js')
+
+module.exports = class ValidationTest extends Action {
+  constructor () {
+    super()
+    this.name = 'validationTest'
+    this.description = 'I will test action input validators.'
+    this.outputExample = {
+      string: 'imAString!'
+    }
+  }
+
+  inputs () {
+    return {
+      string: {
+        required: true,
+        validator: param => {
+          return typeof param === 'string'
+        }
+      }
+    }
+  }
+
+  run ({params, response}) {
+    response.string = params.string
+  }
+}

--- a/classes/actionProcessor.js
+++ b/classes/actionProcessor.js
@@ -206,7 +206,13 @@ module.exports = class ActionProcessor {
             const method = this.prepareStringMethod(validator)
             validatorResponse = await method.call(api, params[key], this)
           }
-          if (validatorResponse !== true) { this.validatorErrors.push(validatorResponse) }
+          if (validatorResponse !== true) {
+            if (validatorResponse === false) {
+              this.validatorErrors.push(new Error(`Input for parameter "${key}" failed validation!`))
+            } else {
+              this.validatorErrors.push(validatorResponse)
+            }
+          }
         } catch (error) {
           this.validatorErrors.push(error)
         }

--- a/test/actions/showDocumentation.js
+++ b/test/actions/showDocumentation.js
@@ -16,7 +16,7 @@ describe('Action: Show Documentation', () => {
 
   it('returns the correct parts', async () => {
     let {documentation, serverInformation} = await api.specHelper.runAction('showDocumentation')
-    expect(Object.keys(documentation).length).to.equal(6) // 6 actions
+    expect(Object.keys(documentation).length).to.equal(7) // 7 actions
     expect(serverInformation.serverName).to.equal('actionhero')
   })
 })

--- a/test/actions/validationTest.js
+++ b/test/actions/validationTest.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+const expect = chai.expect
+chai.use(dirtyChai)
+
+const path = require('path')
+const ActionHero = require(path.join(__dirname, '/../../index.js'))
+const actionhero = new ActionHero.Process()
+let api
+
+describe('Action: Validator', () => {
+  before(async () => { api = await actionhero.start() })
+  after(async () => { await actionhero.stop() })
+
+  it('fails with no params', async () => {
+    let {error} = await api.specHelper.runAction('validationTest', {})
+    expect(error).to.equal('Error: string is a required parameter for this action')
+  })
+
+  it('fails with a number', async () => {
+    let {error} = await api.specHelper.runAction('validationTest', {string: 87})
+    expect(error).to.equal('Error: Input for parameter "string" failed validation!')
+  })
+})


### PR DESCRIPTION
Currently, any param validators that return false do not result in an error response to the action. While the documentation states that a validator should return `true` or an error, having a generic error thrown when `false` is returned results in a slightly more intuitive developer experience.