### PR TITLE
`connection.setStatusCode` for web clients

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "actionhero",
-  "version": "18.0.0",
+  "version": "18.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -249,16 +249,16 @@
         "concat-map": "0.0.1"
       }
     },
-    "browser_fingerprint": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browser_fingerprint/-/browser_fingerprint-1.0.1.tgz",
-      "integrity": "sha512-hWWyPo+gJVLuGMqiDI/5bwi1eMzNi14Lptw0JSfyAIkZb8dNm86x1qcq20Bdbhbd6iM7r2l+LlqHrS1ViJzGyg=="
-    },
     "browser-stdout": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
+    },
+    "browser_fingerprint": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browser_fingerprint/-/browser_fingerprint-1.0.1.tgz",
+      "integrity": "sha512-hWWyPo+gJVLuGMqiDI/5bwi1eMzNi14Lptw0JSfyAIkZb8dNm86x1qcq20Bdbhbd6iM7r2l+LlqHrS1ViJzGyg=="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -671,9 +671,9 @@
       "dev": true
     },
     "docdash-actionhero": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/docdash-actionhero/-/docdash-actionhero-0.0.7.tgz",
-      "integrity": "sha512-0+jkZSJblk7NcEId+hcsMBrnKuNeXbfyPxiQpmHCjpGNB/LVFOgKB4j6okYfq4/T3V9HSsg5U66qvFwlvjkvnA==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/docdash-actionhero/-/docdash-actionhero-0.0.8.tgz",
+      "integrity": "sha512-iD5vdCYR+aOmcj0+C0qDzRbT/1QcWqecf2Z65TJb57Zt2YjbMR8pBvdjS5wlBnJApraMLSjgWEBCHDrSDq2m5g==",
       "dev": true
     },
     "doctrine": {
@@ -2849,15 +2849,6 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -2867,6 +2858,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/servers/web.js
+++ b/servers/web.js
@@ -31,6 +31,10 @@ module.exports = class WebServer extends ActionHero.Server {
     this.connectionCustomMethods = {
       setHeader: (connection, key, value) => {
         connection.rawConnection.res.setHeader(key, value)
+      },
+
+      setStatusCode: (connection, value) => {
+        connection.rawConnection.responseHttpCode = value
       }
     }
   }

--- a/tutorials/actions.md
+++ b/tutorials/actions.md
@@ -339,6 +339,8 @@ If you don't want your action to respond to the client, or you have already sent
 
 If you are certain that your action is only going to be handled by a web server, then a connivence function has been provided to you via `data.connection.setHeader()`. This function is a proxy to the <a href='https://nodejs.org/api/http.html#http_response_setheader_name_value'>Node HTTP Response setHeader</a> function and allows you to set response headers without having to drill into the `data.connection.rawConnection` object. Please be aware, the `data.connection.setHeader()` function will only be available if your action is being handled by a web server. Other server types will throw an exception. See [Servers: Customizing the Connection](tutorial-servers.html) for more details.
 
+Similarly to the above, the web server also exposes `data.connection.setStatusCode()`, again only for actions in use by the web server.  This can be used as a helper to set the HTTP responses' status code, ie: 404, 200, etc.
+
 ## Middleware
 
 You can create middlware which would apply to the connection both before and after an action.  Middleware can be either global (applied to all actions) or local, specified in each action via `action.middleware = []`.  Supply the `names` of any middleware you want to use.

--- a/tutorials/web-server.md
+++ b/tutorials/web-server.md
@@ -86,7 +86,7 @@ exports['default'] = {
         secure: false,
         // Passed to https.createServer if secure=true. Should contain SSL certificates
         serverOptions: {},
-        // Should we redirect all traffic to the first host in this array if hte request header doesn't match?
+        // Should we redirect all traffic to the first host in this array if the request header doesn't match?
         // i.e.: [ 'https://www.site.com' ]
         allowedRequestHosts: process.env.ALLOWED_HOSTS ? process.env.ALLOWED_HOSTS.split(',') : [],
         // Port or Socket Path


### PR DESCRIPTION
A helper for the `web` type of connection to more easily set a custom status code in your actions.  Remember that if you don't want to sent data back to the client, to use `data.toRender = false`:

```js
// actions/custom404.js

const {Action} = require('./../index.js')

module.exports = class Custom404 extends Action {
  constructor () {
    super()
    this.name = 'custom 404 message'
    this.description = 'I return a 404 with a sassy message'
    this.outputExample = {}
  }

  async run ({connection, response}) {
    response.message = 'nope.'
    connection.setStatusCode(404)
  }
}
```