### PR TITLE
Fixed slicing the search of parsed url when only receiving an action on QS.

### DIFF
--- a/servers/web.js
+++ b/servers/web.js
@@ -474,7 +474,12 @@ module.exports = class WebServer extends ActionHero.Server {
     // API
     if (requestMode === 'api') {
       if (connection.rawConnection.method === 'TRACE') { requestMode = 'trace' }
-      let search = connection.rawConnection.parsedURL.search.slice(1)
+      let search = ''
+
+      if (connection.rawConnection.parsedURL.search !== null) {
+        search = connection.rawConnection.parsedURL.search.slice(1)
+      }
+
       this.fillParamsFromWebRequest(connection, qs.parse(search, this.config.queryParseOptions))
       connection.rawConnection.params.query = connection.rawConnection.parsedURL.query
       if (

--- a/test/servers/web.js
+++ b/test/servers/web.js
@@ -309,6 +309,15 @@ describe('Server: Web', () => {
     }
   })
 
+  it('should not reject promise with fatal when sending only action on url on node 9', async () => {
+    try {
+      let body = await request.get(url + '/api/status').then(toJson)
+      expect(body.error).to.not.exist()
+    } catch (error) {
+      throw new Error('should not get here, request should succeed')
+    }
+  })
+
   it('real actions do not have an error response', async () => {
     let body = await request.get(url + '/api/status').then(toJson)
     expect(body.error).to.not.exist()


### PR DESCRIPTION
Hello guys,
I tried to follow the guideline, please let me know if you want me to change something.

The issue I'm trying to fix on this commit is: https://github.com/actionhero/actionhero/issues/1149
which is related to this node fix: nodejs/node#13404

I wrote a test which is pretty similar to the rest, since the tests were not passing anyway on node 9. 

After this fix all tests pass again.

Thanks