### PR TITLE
action validators which return nothing are valid

### DIFF
--- a/classes/actionProcessor.js
+++ b/classes/actionProcessor.js
@@ -206,6 +206,11 @@ module.exports = class ActionProcessor {
             const method = this.prepareStringMethod(validator)
             validatorResponse = await method.call(api, params[key], this)
           }
+
+          // validator function returned nothing; assume param is OK
+          if (validatorResponse === null || validatorResponse === undefined) { return }
+
+          // validator returned something that was not `true`
           if (validatorResponse !== true) {
             if (validatorResponse === false) {
               this.validatorErrors.push(new Error(`Input for parameter "${key}" failed validation!`))
@@ -214,6 +219,7 @@ module.exports = class ActionProcessor {
             }
           }
         } catch (error) {
+          // validator threw an error
           this.validatorErrors.push(error)
         }
       }

--- a/test/core/api.js
+++ b/test/core/api.js
@@ -178,7 +178,7 @@ describe('Core: API', () => {
               required: false,
               default: () => { return 'abc123' },
               validator: function (s) {
-                if (s === 'abc123') { return true } else { return 'fancyParam should be "abc123".  so says ' + this.id }
+                if (s !== 'abc123') { return 'fancyParam should be "abc123".  so says ' + this.id }
               },
               formatter: function (s) {
                 return String(s)
@@ -240,6 +240,11 @@ describe('Core: API', () => {
     it('will use formatter if provided (and still use validator)', async () => {
       let response = await api.specHelper.runAction('testAction', {requiredParam: true, fancyParam: 123})
       expect(response.requesterInformation.receivedParams.fancyParam).to.equal('123')
+    })
+
+    it('succeeds a validator which returns no response', async () => {
+      let response = await api.specHelper.runAction('testAction', {requiredParam: true, fancyParam: 'abc123'})
+      expect(response.error).to.not.exist()
     })
 
     it('will filter params not set in the target action or global safelist', async () => {

--- a/tutorials/actions.md
+++ b/tutorials/actions.md
@@ -32,7 +32,7 @@ You can also define more than one action per file if you would like, and extend 
 
 ```js
 // Compound Action with Shared Inputs//
-const {Action, api} = require('actionhero')
+const {Action} = require('actionhero')
 
 class ValidatedAction extends Action {
   constructor () {
@@ -50,7 +50,7 @@ class ValidatedAction extends Action {
   }
 
   emailValidator (param) {
-    if (email.indexOf('@') < 0) {
+    if (param.indexOf('@') < 0) {
       throw new Error('that is not a valid email address')
     }
   }
@@ -139,7 +139,7 @@ class ValidatedAction extends Action {
       multiplier: {
         required: false,
         validator: (param, connection, actionTemplate) => {
-          if (param < 0) { throw new Error('must be > 0') } else { return true }
+          if (param < 0) { throw new Error('must be > 0') }
         },
         formatter: (param, connection, actionTemplate) => {
           return parseInt(param)
@@ -197,7 +197,7 @@ action.inputs = {
   multiplier: {
     required: true,
     validator: (param, connection, actionTemplate) => {
-      if (param < 0) { throw new Error('must be > 0') } else { return true }
+      if (param < 0) { throw new Error('must be > 0') }
     },
     formatter: (param, connection, actionTemplate) => {
       return parseInt(param);
@@ -216,7 +216,7 @@ action.inputs = {
         required: true,
         default: 1,
         validator: (param, connection, actionTemplate) => {
-          if (param < 0) { throw new Error('must be > 0') } else { return true }
+          if (param < 0) { throw new Error('must be > 0') }
         },
         formatter: (param, connection, actionTemplate) => {
           return parseInt(param);
@@ -240,7 +240,7 @@ The properties of an input are:
   * you can also have a static assignment for `default` father than a function, ie: `default: 123`
   * Default: Parameter has no default value
 * `validator = function(param, connection, actionTemplate)`
-  * should return true if validation passed
+  * should return true, null, or undefined (return nothing) if validation passed
   * should throw an error message if validation fails which will be returned to the client
   * Default: Parameter is always valid
 * `schema` (object)
@@ -271,7 +271,6 @@ moneyInCents: {
   validator: (p) => {
     if(isNaN(parseFloat(p)){ throw new Error('not a number') }
     if(p < 0){ throw new Error('money cannot be negative') }
-    else{ return true }
   }
 }
 ```


### PR DESCRIPTION
Changes the behavior of action's param validators to only mark a param as invalid if they return `false` or throw an error.  Previously, validators which did not return (or returned null) would be marked as failing. 

Solves https://github.com/actionhero/actionhero/issues/1155.