### PR TITLE
Issue with unclosed file descriptors

### DIFF
--- a/classes/server.js
+++ b/classes/server.js
@@ -142,7 +142,7 @@ module.exports = class MyServer extends Server {
    * @memberof ActionHero.Server
    * @param  {Object}  connection The connection in question.
    * @param  {Error}   error If there was any errror finding or reading this file.
-   * @param  {Object}  fileStream A stream from the file reader which can be piped to the connection.
+   * @param  {Object}  fileStream A stream from the file reader which can be piped to the connection. Has to be explicitly closed if not piped.
    * @param  {string}  mime The mime type of the files
    * @param  {Number}  length The length in bytes of the file.  Useful for setting headers.
    * @param  {Date}    lastModified The timestamp when the file was last modifeid on disk.  Useful for headers.

--- a/servers/web.js
+++ b/servers/web.js
@@ -142,6 +142,7 @@ module.exports = class WebServer extends ActionHero.Server {
         connection.rawConnection.res.writeHead(responseHttpCode, this.transformHeaders(headers))
         connection.rawConnection.res.end()
         connection.destroy()
+        fileStream.close()
       }
     }
 


### PR DESCRIPTION
Found an issue in the action hero web server. If the web server sends a status code 304 response, then the fileStream handle is not closed.
200s are not affected, because their streams get automatically closed by pipe().