### PR TITLE
No need for a timer to check file locks in development mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Or deploy a free API server now:
 - [Socket Server](https://docs.actionherojs.com/tutorial-socket-server.html)
 - [WebSocket Server](https://docs.actionherojs.com/tutorial-websocket-server.html)
 
-### Testing, Deployment, and Operations 
+### Testing, Deployment, and Operations
 - [Running ActionHero](https://docs.actionherojs.com/tutorial-running-actionhero.html)
 - [Development Mode & REPL](https://docs.actionherojs.com/tutorial-development-mode.html)
 - [Testing & SpecHelper](https://docs.actionherojs.com/tutorial-testing.html)

--- a/initializers/config.js
+++ b/initializers/config.js
@@ -60,7 +60,6 @@ module.exports = class Config extends ActionHero.Initializer {
             let cleanPath = file
             if (process.platform === 'win32') { cleanPath = file.replace(/\//g, '\\') }
             delete require.cache[require.resolve(cleanPath)]
-            setTimeout(() => { api.watchedFiles[file].blocked = false }, 1000)
             handler(file)
           }
         })


### PR DESCRIPTION
`api.watchedFiles[file].blocked` is an unused artifact from a previous version of ActionHero.  Remove it!

Solves https://github.com/actionhero/actionhero/issues/1162