### PR TITLE
connetion#pipe for web servers sending buffers or strings

### DIFF
--- a/classes/connection.js
+++ b/classes/connection.js
@@ -110,6 +110,24 @@ module.exports = class Connection {
     return api.i18n.localize(message, this)
   }
 
+  /**
+   * Send a file to a connection (usually in the context of an Action).  Be sure to set `data.toRender = false` in the action!
+   * Uses Server#processFile and will set `connection.params.file = path`
+   *
+   * @function sendFile
+   * @memberof ActionHero.Connection
+   * @param  {String} path The path of the file to send, within one of your `api.config.general.paths.public` directories.
+   * @tutorial file-server
+   */
+
+  /**
+   * Send a message to a connection.  Uses Server#sendMessage.
+   *
+   * @function sendMessage
+   * @memberof ActionHero.Connection
+   * @param  {String} message The message to send.  Can be an Object or String... but it depends on the server in use.
+   */
+
   generateID () {
     return uuid.v4()
   }

--- a/servers/web.js
+++ b/servers/web.js
@@ -35,6 +35,12 @@ module.exports = class WebServer extends ActionHero.Server {
 
       setStatusCode: (connection, value) => {
         connection.rawConnection.responseHttpCode = value
+      },
+
+      pipe: (connection, buffer, headers) => {
+        for (let k in headers) { connection.setHeader(k, headers[k]) }
+        if (typeof buffer === 'string') { buffer = Buffer.from(buffer) }
+        connection.rawConnection.res.end(buffer)
       }
     }
   }

--- a/tutorials/actions.md
+++ b/tutorials/actions.md
@@ -336,9 +336,11 @@ You can also modify properties of the connection by accessing `data.connection`,
 
 If you don't want your action to respond to the client, or you have already sent data to the client (perhaps you already rendered a file to them or sent an error HTTP header), you can set `data.toRender = false;`
 
-If you are certain that your action is only going to be handled by a web server, then a connivence function has been provided to you via `data.connection.setHeader()`. This function is a proxy to the <a href='https://nodejs.org/api/http.html#http_response_setheader_name_value'>Node HTTP Response setHeader</a> function and allows you to set response headers without having to drill into the `data.connection.rawConnection` object. Please be aware, the `data.connection.setHeader()` function will only be available if your action is being handled by a web server. Other server types will throw an exception. See [Servers: Customizing the Connection](tutorial-servers.html) for more details.
+If you are certain that your action is only going to be handled by a web server, then a convenience method has been provided to you via `data.connection.setHeader()`. This function is a proxy to the <a href='https://nodejs.org/api/http.html#http_response_setheader_name_value'>Node HTTP Response setHeader</a> function and allows you to set response headers without having to drill into the `data.connection.rawConnection` object. Please be aware, the `data.connection.setHeader()` function will only be available if your action is being handled by a web server. Other server types will throw an exception. See [Servers: Customizing the Connection](tutorial-servers.html) for more details.
 
 Similarly to the above, the web server also exposes `data.connection.setStatusCode()`, again only for actions in use by the web server.  This can be used as a helper to set the HTTP responses' status code, ie: 404, 200, etc.
+
+Finally, if your action is again only for the web server, you can send a string or buffer as a file response with `data.connection.pipe(buffer, headers)`.  You will still need to set `data.toRender = false` in your action to avoid double-sending a response to the client. 
 
 ## Middleware
 


### PR DESCRIPTION
solves https://github.com/actionhero/actionhero/issues/1142.

```js
const {Action} = require('actionhero')

module.exports = class StringResponse extends Action {
  constructor () {
    super()
    this.name = 'stringResponse'
    this.description = 'I send a string to the client as if it were a file'
  }

  async run (data) {
    data.toRun = false
    data.connection.pipe('my response', {'content-type': 'text/plain'})
  }
}

```

Adds `connection.pipe(string-or-buffer, headers)` which can be used in your actions for web clients.  This is a helper method which is the same as:

```js
data.connection.setHeader('Content-Type', 'application/xml; charset=utf-8')
data.connection.rawConnection.res.end(fileBuffer)
```

`data.toRender = false` is still needed within the Action's run method.