### PR TITLE
Fix: Actionhero fails to parse locally scoped IPv6 addresses

### DIFF
--- a/initializers/utils.js
+++ b/initializers/utils.js
@@ -264,7 +264,7 @@ let responses = await api.utils.asyncWaterfall(jobs)
     api.utils.parseIPv6URI = (addr) => {
       let host = '::1'
       let port = '80'
-      let regexp = new RegExp(/\[([0-9a-f:]+)]:([0-9]{1,5})/)
+      let regexp = new RegExp(/\[([0-9a-f:]+(?:%.+)?)]:([0-9]{1,5})/)
       // if we have brackets parse them and find a port
       if (addr.indexOf('[') > -1 && addr.indexOf(']') > -1) {
         let res = regexp.exec(addr)

--- a/test/utils/utils.js
+++ b/test/utils/utils.js
@@ -143,6 +143,20 @@ describe('Utils', () => {
         expect(e.message).to.equal('failed to parse address')
       }
     })
+
+    it('should parse locally scoped ipv6 URIs without port', () => {
+      let uri = 'fe80::1ff:fe23:4567:890a%eth2'
+      let parts = api.utils.parseIPv6URI(uri)
+      expect(parts.host).to.equal('fe80::1ff:fe23:4567:890a%eth2')
+      expect(parts.port).to.equal(80)
+    })
+
+    it('should parse locally scoped ipv6 URIs with port', () => {
+      let uri = '[fe80::1ff:fe23:4567:890a%eth2]:8080'
+      let parts = api.utils.parseIPv6URI(uri)
+      expect(parts.host).to.equal('fe80::1ff:fe23:4567:890a%eth2')
+      expect(parts.port).to.equal(8080)
+    })
   })
 
   describe('utils.filterObjectForLogging', () => {


### PR DESCRIPTION
* fix ipv6 parsing for locally scoped URIs
+ added tests for locally scoped URIs

Resolves #1178 