### PR TITLE
generic error decoration hook for action errors, CLI docs cleanup

### DIFF
--- a/classes/actionProcessor.js
+++ b/classes/actionProcessor.js
@@ -46,7 +46,7 @@ module.exports = class ActionProcessor {
     this.actionStatus = String(status)
 
     if (status instanceof Error) {
-      error = status
+      error = await api.config.errors.genericError(this, status)
     } else if (status === 'server_shutting_down') {
       error = await api.config.errors.serverShuttingDown(this)
     } else if (status === 'too_many_requests') {
@@ -60,7 +60,7 @@ module.exports = class ActionProcessor {
     } else if (status === 'validator_errors') {
       error = await api.config.errors.invalidParams(this, this.validatorErrors)
     } else if (status) {
-      error = status
+      error = await api.config.errors.genericStatus(this, status)
     }
 
     if (error && typeof error === 'string') {

--- a/classes/actionProcessor.js
+++ b/classes/actionProcessor.js
@@ -60,7 +60,7 @@ module.exports = class ActionProcessor {
     } else if (status === 'validator_errors') {
       error = await api.config.errors.invalidParams(this, this.validatorErrors)
     } else if (status) {
-      error = await api.config.errors.genericStatus(this, status)
+      error = status
     }
 
     if (error && typeof error === 'string') {

--- a/config/errors.js
+++ b/config/errors.js
@@ -83,6 +83,16 @@ exports['default'] = {
         return api.i18n.localize(['actionhero.errors.dataLengthTooLarge', {maxLength: maxLength, receivedLength: receivedLength}])
       },
 
+      // Decorate your response based on Error here
+      async genericError (data, error) {
+        return error
+      },
+
+      // Decorate your response based on status value
+      async genericStatus (data, status) {
+        return status
+      },
+
       // ///////////////
       // FILE SERVER //
       // ///////////////

--- a/config/errors.js
+++ b/config/errors.js
@@ -83,14 +83,11 @@ exports['default'] = {
         return api.i18n.localize(['actionhero.errors.dataLengthTooLarge', {maxLength: maxLength, receivedLength: receivedLength}])
       },
 
-      // Decorate your response based on Error here
+      // Decorate your response based on Error here.
+      // Any action that throws an Error will pass through this method before returning
+      //   an error to the client. Reponse can be edited here, status codes changed, etc.
       async genericError (data, error) {
         return error
-      },
-
-      // Decorate your response based on status value
-      async genericStatus (data, status) {
-        return status
       },
 
       // ///////////////

--- a/tutorials/actions.md
+++ b/tutorials/actions.md
@@ -340,7 +340,7 @@ If you are certain that your action is only going to be handled by a web server,
 
 Similarly to the above, the web server also exposes `data.connection.setStatusCode()`, again only for actions in use by the web server.  This can be used as a helper to set the HTTP responses' status code, ie: 404, 200, etc.
 
-Finally, if your action is again only for the web server, you can send a string or buffer as a file response with `data.connection.pipe(buffer, headers)`.  You will still need to set `data.toRender = false` in your action to avoid double-sending a response to the client. 
+Finally, if your action is again only for the web server, you can send a string or buffer as a file response with `data.connection.pipe(buffer, headers)`.  You will still need to set `data.toRender = false` in your action to avoid double-sending a response to the client.
 
 ## Middleware
 
@@ -351,7 +351,7 @@ You can [learn more about middleware here](tutorial-middleware.html).
 ## Notes
 
 * Actions' run method are async, and have `data` as their only argument.  Completing an action is as simple returning from the method.  
-* If you throw an error, be sure that it is a `new Error()` object, and not a string.  Thrown errors will automatically be sent to the client in `response.error`
+* If you throw an error, be sure that it is a `new Error()` object, and not a string.  Thrown errors will automatically be sent to the client in `response.error`. Also, throw Errors are processed at `config/errors.js` in `genericError(data, error)`. Here you can check your error add to the response (`requestIds`, status codes, etc.)
 * The metadata `outputExample` is used in reflexive and self-documenting actions in the API, available via the `documentation` verb (and showDocumenation action).
 * You can limit how many actions a persistent client (websocket, tcp, etc) can have pending at once with `api.config.general.simultaneousActions`
 * `actions.inputs` are used for both documentation and for building the whitelist of allowed parameters the API will accept.  Client params not included in these whitelists will be ignored for security. If you wish to disable the whitelisting you can use the flag at `api.config.general.disableParamScrubbing`. Note that [Middleware](tutorial-middleware.html) preProcessors will always have access to all params pre-scrubbing.

--- a/tutorials/cli.md
+++ b/tutorials/cli.md
@@ -20,14 +20,14 @@ module.exports = class RedisKeys extends CLI {
   inputs () {
     return {
       prefix: {
-        requried: true,
+        required: true,
         default: 'actionhero',
         note: 'the redis prefix for searching keys'
       }
     }
   }
 
-  async run ({params}) => {
+  async run ({params}) {
     let keys = await api.redis.clients.client.keys(params.prefix)
     api.log('Found ' + keys.length + 'keys:')
     keys.forEach((k) => { api.log(k) })


### PR DESCRIPTION
As discussed [in Slack channel](https://actionherojs.slack.com/archives/C04EVSUSD/p1518021134000659), Actions that throw an error get a generic hander in `api.config.errors.genericError`. Here the `data.response` could be decorated however needed, like added a `requestId`, or whatever. Default is pure passthrough.

Added the same for a plain `status` that is not an error, just for consistency. Default is passthrough. 

Few tweaks to CLI documentation. 