### PR TITLE
Adds gitignore to the copied files list

### DIFF
--- a/bin/methods/generate.js
+++ b/bin/methods/generate.js
@@ -109,7 +109,7 @@ module.exports = class Generate extends ActionHero.CLI {
       '/README.md': 'readmeMd',
       '/test/example.js': 'exampleTest',
       '/locales/en.json': 'enLocale',
-      '/.gitignore':'gitignore'
+      '/.gitignore': 'gitignore'
     }
 
     for (let file in newFileMap) {

--- a/bin/methods/generate.js
+++ b/bin/methods/generate.js
@@ -38,7 +38,8 @@ module.exports = class Generate extends ActionHero.CLI {
       publicLogo: '/public/logo/actionhero.png',
       publicCss: '/public/css/cosmo.css',
       exampleTest: '/test/template.js.example',
-      enLocale: '/locales/en.json'
+      enLocale: '/locales/en.json',
+      gitignore: '/.gitignore'
     }
 
     for (let name in oldFileMap) {
@@ -107,7 +108,8 @@ module.exports = class Generate extends ActionHero.CLI {
       '/public/logo/actionhero.png': 'publicLogo',
       '/README.md': 'readmeMd',
       '/test/example.js': 'exampleTest',
-      '/locales/en.json': 'enLocale'
+      '/locales/en.json': 'enLocale',
+      '/.gitignore':'gitignore'
     }
 
     for (let file in newFileMap) {

--- a/test/core/cli.js
+++ b/test/core/cli.js
@@ -127,7 +127,8 @@ describe('Core: CLI', () => {
         'locales/en.json',
         'tasks',
         'test',
-        'test/example.js'
+        'test/example.js',
+        '.gitignore'
       ].forEach((f) => {
         expect(fs.existsSync(testDir + '/' + f)).to.equal(true)
       })


### PR DESCRIPTION
Fixes issue https://github.com/actionhero/actionhero/issues/1188

Copies the root `.gitignore` file into generated projects. 

@evantahler I added the lines as you pointed out - pretty straightforward, thanks for the direction. I added the test and all tests pass; but, I couldn't figure out how to run the generate command locally. I saw the `sample.sh` file in the project root, but running that did not create the `.gitignore` file in the tmp directory - but it looked like maybe that would run from the npm installed version of actionhero instead of my clone of the repository? Any hints on how to do a quick manual check of this functionality using my local repo?