### PR TITLE
Capture full rawBody even if formidable fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "postinstall": "echo 'To generate a new actionhero project, run \"npx actionhero generate\"'",
     "help": "node ./bin/actionhero help",
     "test": "cross-env NODE_ENV=test mocha",
-    "grepTest": "cross-env NODE_ENV=test mocha --grep $1",
     "pretest": "standard",
     "start": "node ./bin/actionhero",
     "docs": "jsdoc -c jsdoc-conf.json"

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "postinstall": "echo 'To generate a new actionhero project, run \"npx actionhero generate\"'",
     "help": "node ./bin/actionhero help",
     "test": "cross-env NODE_ENV=test mocha",
+    "grepTest": "cross-env NODE_ENV=test mocha --grep $1",
     "pretest": "standard",
     "start": "node ./bin/actionhero",
     "docs": "jsdoc -c jsdoc-conf.json"

--- a/servers/web.js
+++ b/servers/web.js
@@ -479,26 +479,12 @@ module.exports = class WebServer extends ActionHero.Server {
         if (this.config.saveRawBody) {
           connection.rawConnection.req.on('data', (chunk) => { rawBody = Buffer.concat([rawBody, chunk]) })
         }
-        // let rawBody = Promise.resolve(Buffer.alloc(0))
-        // if (this.config.saveRawBody) {
-        //   rawBody = new Promise((resolve, reject) => {
-        //     let fullBody = Buffer.alloc(0)
-        //     if (!connection.rawConnection || !connection.rawConnection.req) {
-        //       return resolve(fullBody)
-        //     }
-        //     connection.rawConnection.req
-        //       .on('error', (err) => { reject(err) })
-        //       .on('aborted', () => { reject(new Error('Request aborted while saveRawBody')) })
-        //       .on('data', (chunk) => { fullBody = Buffer.concat([fullBody, chunk]) })
-        //       .on('end', () => { resolve(fullBody) })
-        //   })
-        // }
 
         let {fields, files} = await new Promise((resolve) => {
           connection.rawConnection.form.parse(connection.rawConnection.req, (error, fields, files) => {
             if (error) {
-              if (error.message.indexOf('unknown content-type') > -1 && this.config.saveRawBody) {
-                this.log('Formidable failed. Request stream is not in formbidable', 'error')
+              if (this.config.saveRawBody) {
+                // this.log('Formidable failed. Request body saved to connection.rawConnection.params.rawBody')
               } else {
                 connection.error = new Error('There was an error processing this form.')
               }

--- a/servers/web.js
+++ b/servers/web.js
@@ -475,10 +475,6 @@ module.exports = class WebServer extends ActionHero.Server {
           connection.rawConnection.form[i] = this.config.formOptions[i]
         }
 
-        // let rawBody = Buffer.alloc(0)
-        // if (this.config.saveRawBody) {
-        //   connection.rawConnection.req.on('data', (chunk) => { rawBody = Buffer.concat([rawBody, chunk]) })
-        // }
         let rawBody = Promise.resolve(Buffer.alloc(0))
         if (this.config.saveRawBody) {
           rawBody = new Promise((resolve, reject) => {
@@ -498,6 +494,7 @@ module.exports = class WebServer extends ActionHero.Server {
             resolve({fields, files})
           })
         })
+
         connection.rawConnection.params.body = fields
         connection.rawConnection.params.rawBody = await rawBody
         connection.rawConnection.params.files = files

--- a/servers/web.js
+++ b/servers/web.js
@@ -479,17 +479,33 @@ module.exports = class WebServer extends ActionHero.Server {
         if (this.config.saveRawBody) {
           connection.rawConnection.req.on('data', (chunk) => { rawBody = Buffer.concat([rawBody, chunk]) })
         }
+        // let rawBody = Promise.resolve(Buffer.alloc(0))
+        // if (this.config.saveRawBody) {
+        //   rawBody = new Promise((resolve, reject) => {
+        //     let fullBody = Buffer.alloc(0)
+        //     if (!connection.rawConnection || !connection.rawConnection.req) {
+        //       return resolve(fullBody)
+        //     }
+        //     connection.rawConnection.req
+        //       .on('error', (err) => { reject(err) })
+        //       .on('aborted', () => { reject(new Error('Request aborted while saveRawBody')) })
+        //       .on('data', (chunk) => { fullBody = Buffer.concat([fullBody, chunk]) })
+        //       .on('end', () => { resolve(fullBody) })
+        //   })
+        // }
 
         let {fields, files} = await new Promise((resolve) => {
           connection.rawConnection.form.parse(connection.rawConnection.req, (error, fields, files) => {
             if (error) {
-              this.log('error processing form: ' + String(error), 'error')
-              connection.error = new Error('There was an error processing this form.')
+              if (error.message.indexOf('unknown content-type') > -1 && this.config.saveRawBody) {
+                this.log('Formidable failed. Request stream is not in formbidable', 'error')
+              } else {
+                connection.error = new Error('There was an error processing this form.')
+              }
             }
             resolve({fields, files})
           })
         })
-
         connection.rawConnection.params.body = fields
         connection.rawConnection.params.rawBody = rawBody
         connection.rawConnection.params.files = files

--- a/test/servers/web.js
+++ b/test/servers/web.js
@@ -442,24 +442,10 @@ describe('Server: Web', () => {
           expect(body.rawBody).to.equal(requestBody)
         })
 
-        it('.body will be empty if the content-type cannot be handled by formidable', async () => {
+        it('rawBody will exist if the content-type cannot be handled by formidable', async () => {
           let innerNoteList = ''
           for (let i = 0; i < 1000; i++) { innerNoteList += `<innerNode>innerNode${i}</innerNode>` }
           let requestBody = `<texty>${innerNoteList}</texty>`
-          // var bufferStream = new PassThrough()
-          // bufferStream.end(Buffer.from(requestBody))
-          // var req = request.post(url + '/api/paramTestAction', {headers: {'Content-type': 'text/xml'}})
-          // bufferStream.pipe(req)
-          //
-          // await new Promise((resolve, reject) => {
-          //   bufferStream.on('close', () => { console.log('Closing bufferStream') })
-          //   bufferStream.on('drain', () => { console.log('Drain bufferStream') })
-          //   bufferStream.on('error', (e) => { console.log('Error bufferStream ' + e) })
-          //   bufferStream.on('finish', resolve)
-          // })
-          // var respString = await req
-          // var resp = JSON.parse(respString)
-          // console.log('resp: ' + JSON.stringify(resp))
 
           let resp = await request.post(url + '/api/paramTestAction', {'body': requestBody, 'headers': {'Content-type': 'text/xml'}}).then(toJson)
           expect(resp.error).to.not.exist()

--- a/test/servers/web.js
+++ b/test/servers/web.js
@@ -10,6 +10,7 @@ const fs = require('fs')
 const os = require('os')
 const path = require('path')
 const {promisify} = require('util')
+// const {PassThrough} = require('stream')
 const ActionHero = require(path.join(__dirname, '/../../index.js'))
 const actionhero = new ActionHero.Process()
 let api
@@ -439,6 +440,31 @@ describe('Server: Web', () => {
           let body = await request.post(url + '/api/paramTestAction', {'body': requestBody, 'headers': {'Content-type': 'application/json'}}).then(toJson)
           expect(body.body).to.deep.equal({})
           expect(body.rawBody).to.equal(requestBody)
+        })
+
+        it('.body will be empty if the content-type cannot be handled by formidable', async () => {
+          let innerNoteList = ''
+          for (let i = 0; i < 1000; i++) { innerNoteList += `<innerNode>innerNode${i}</innerNode>` }
+          let requestBody = `<texty>${innerNoteList}</texty>`
+          // var bufferStream = new PassThrough()
+          // bufferStream.end(Buffer.from(requestBody))
+          // var req = request.post(url + '/api/paramTestAction', {headers: {'Content-type': 'text/xml'}})
+          // bufferStream.pipe(req)
+          //
+          // await new Promise((resolve, reject) => {
+          //   bufferStream.on('close', () => { console.log('Closing bufferStream') })
+          //   bufferStream.on('drain', () => { console.log('Drain bufferStream') })
+          //   bufferStream.on('error', (e) => { console.log('Error bufferStream ' + e) })
+          //   bufferStream.on('finish', resolve)
+          // })
+          // var respString = await req
+          // var resp = JSON.parse(respString)
+          // console.log('resp: ' + JSON.stringify(resp))
+
+          let resp = await request.post(url + '/api/paramTestAction', {'body': requestBody, 'headers': {'Content-type': 'text/xml'}}).then(toJson)
+          expect(resp.error).to.not.exist()
+          expect(resp.body).to.deep.equal({})
+          expect(resp.rawBody).to.equal(requestBody)
         })
       })
     })

--- a/test/servers/web.js
+++ b/test/servers/web.js
@@ -10,7 +10,6 @@ const fs = require('fs')
 const os = require('os')
 const path = require('path')
 const {promisify} = require('util')
-// const {PassThrough} = require('stream')
 const ActionHero = require(path.join(__dirname, '/../../index.js'))
 const actionhero = new ActionHero.Process()
 let api


### PR DESCRIPTION
(if this gets accepted, definitely need to `squash` all the commits!)

Quick test can be run with `npm run grepTest "mime"`  (I use that locally in my `package.json`, and can remove if you don't want it in master)

Added processing that awaits for 'end' event from rawBody.

Tests try to simulate what a (slow/actual) network will do for data. If formidable fails, the connection processing finishes **before** the (full) request body is processed. In that case, `rawConnection.params.rawBody` is not available (empty) in middleware or actions. Tests also try to show that normal JSON/formidable processing still works and errors do not hang.

Thoughts on this? There are some comments I will remove, but wanted to check on the approach first.

I used this middleware when processing with my legacy stuff, simply looking for action input `mimeText`

```
var RawMimeMiddleware = {
      name: 'rawMime',
      global: false,
      priority: 1010,
      preProcessor: function (data) {
        if (data.connection.rawConnection && data.connection.rawConnection.params &&
            data.connection.rawConnection.params.rawBody) {
          data.params.mimeText = data.connection.rawConnection.params.rawBody.toString()
        }
      }
    }

    api.actions.addMiddleware(RawMimeMiddleware)
```