### PR TITLE
Fixed issue #1207. Chat middleware not bubbling up appropriately.

### DIFF
--- a/__tests__/core/chatRoom.js
+++ b/__tests__/core/chatRoom.js
@@ -284,7 +284,7 @@ describe('Core', () => {
         test('(say) can modify message payloads', async () => {
           api.chatRoom.addMiddleware({
             name: 'chat middleware',
-            say: (connection, room, messagePayload) => {
+            say: async (connection, room, messagePayload) => {
               if (messagePayload.from !== 0) { messagePayload.message = 'something else' }
               return messagePayload
             }
@@ -305,7 +305,7 @@ describe('Core', () => {
             api.chatRoom.addMiddleware({
               name: 'chat middleware 1',
               priority: 1000,
-              say: (connection, room, messagePayload, callback) => {
+              say: async (connection, room, messagePayload, callback) => {
                 messagePayload.message = 'MIDDLEWARE 1'
                 return messagePayload
               }
@@ -314,7 +314,7 @@ describe('Core', () => {
             api.chatRoom.addMiddleware({
               name: 'chat middleware 2',
               priority: 2000,
-              say: (connection, room, messagePayload) => {
+              say: async (connection, room, messagePayload) => {
                 messagePayload.message = messagePayload.message + ' MIDDLEWARE 2'
                 return messagePayload
               }
@@ -333,7 +333,7 @@ describe('Core', () => {
         test('say middleware can block excecution', async () => {
           api.chatRoom.addMiddleware({
             name: 'chat middleware',
-            say: (connection, room, messagePayload) => {
+            say: async (connection, room, messagePayload) => {
               throw new Error('messages blocked')
             }
           })
@@ -351,7 +351,7 @@ describe('Core', () => {
         test('join middleware can block excecution', async () => {
           api.chatRoom.addMiddleware({
             name: 'chat middleware',
-            join: (connection, room) => {
+            join: async (connection, room) => {
               throw new Error('joining rooms blocked')
             }
           })
@@ -368,7 +368,7 @@ describe('Core', () => {
         test('leave middleware can block excecution', async () => {
           api.chatRoom.addMiddleware({
             name: 'chat middleware',
-            leave: (connection, room) => {
+            leave: async (connection, room) => {
               throw new Error('Hotel California')
             }
           })

--- a/__tests__/core/chatRoom.js
+++ b/__tests__/core/chatRoom.js
@@ -314,7 +314,7 @@ describe('Core', () => {
             api.chatRoom.addMiddleware({
               name: 'chat middleware 2',
               priority: 2000,
-              say: async (connection, room, messagePayload) => {
+              say: (connection, room, messagePayload) => {
                 messagePayload.message = messagePayload.message + ' MIDDLEWARE 2'
                 return messagePayload
               }

--- a/bin/deploy-docs
+++ b/bin/deploy-docs
@@ -53,8 +53,11 @@ build_branch "v17" $VERSION_V17
 VERSION_V18=$(git tag --sort=refname | grep v18 | tail -n1)
 build_branch $VERSION_V18 $VERSION_V18
 
+VERSION_V19=$(git tag --sort=refname | grep v19 | tail -n1)
+build_branch $VERSION_V19 $VERSION_V19
+
 ## Build a version referance file for the site
-echo "var DOCUMENTATION_VERSIONS = ['master', '$VERSION_V18', '$VERSION_V17']" >> gh-pages-branch/scripts/VERSIONS.js
+echo "var DOCUMENTATION_VERSIONS = ['master', '$VERSION_V18', '$VERSION_V17', '$VERSION_V19']" >> gh-pages-branch/scripts/VERSIONS.js
 
 ## push it
 cd gh-pages-branch
@@ -65,4 +68,4 @@ cd ..
 
 ## clean up
 rm -rf gh-pages-branch
-echo "Depolyment Complete"
+echo "Deployment Complete"

--- a/initializers/chatRoom.js
+++ b/initializers/chatRoom.js
@@ -418,26 +418,19 @@ class ChatRoom extends ActionHero.Initializer {
      */
     api.chatRoom.runMiddleware = async (connection, room, direction, messagePayload) => {
       let newMessagePayload
-      let toReturn = true
       if (messagePayload) { newMessagePayload = Object.assign({}, messagePayload) }
 
-      api.chatRoom.globalMiddleware.forEach(async (name) => {
+      for (let name of api.chatRoom.globalMiddleware) {
         const m = api.chatRoom.middleware[name]
-        try {
-          if (typeof m[direction] === 'function') {
-            if (messagePayload) {
-              let data = await m[direction](connection, room, newMessagePayload)
-              if (data) { newMessagePayload = data }
-            } else {
-              await m[direction](connection, room)
-            }
+        if (typeof m[direction] === 'function') {
+          if (messagePayload) {
+            let data = await m[direction](connection, room, newMessagePayload)
+            if (data) { newMessagePayload = data }
+          } else {
+            await m[direction](connection, room)
           }
-        } catch (error) {
-          toReturn = error
         }
-      })
-
-      if (toReturn !== true) { return toReturn }
+      }
       return newMessagePayload
     }
   }

--- a/initializers/chatRoom.js
+++ b/initializers/chatRoom.js
@@ -192,9 +192,7 @@ class ChatRoom extends ActionHero.Initializer {
       if (connection.canChat === true && connection.rooms.indexOf(messagePayload.room) > -1) {
         try {
           const newMessagePayload = await api.chatRoom.runMiddleware(connection, messagePayload.room, 'say', messagePayload)
-          if (!(newMessagePayload instanceof Error)) {
-            connection.sendMessage(newMessagePayload, 'say')
-          }
+          connection.sendMessage(newMessagePayload, 'say')
         } catch (error) {
           api.log(error, 'warning', {messagePayload, connection})
         }
@@ -358,8 +356,7 @@ class ChatRoom extends ActionHero.Initializer {
       }
 
       if (connection.rooms.indexOf(room) < 0) {
-        let response = await api.chatRoom.runMiddleware(connection, room, 'join')
-        if (response instanceof Error) { throw response }
+        await api.chatRoom.runMiddleware(connection, room, 'join')
       }
 
       if (connection.rooms.indexOf(room) < 0) {
@@ -400,8 +397,7 @@ class ChatRoom extends ActionHero.Initializer {
       }
 
       if (connection.rooms.indexOf(room) >= 0) {
-        let response = await api.chatRoom.runMiddleware(connection, room, 'leave')
-        if (response instanceof Error) { throw response }
+        await api.chatRoom.runMiddleware(connection, room, 'leave')
       }
 
       if (connection.rooms.indexOf(room) >= 0) {


### PR DESCRIPTION
Pointing to issue : #1207 
.forEach built in function does not work properly with async functions. Replaced as per suggestions to use for loop in series.

Updated tests that did not had the async directive on the middleware functions ( causing the tests to pass erroneously ) After putting async directive to wrap up the call in promise, the issue was reproduced.

Then after adding the suggested code with @chimmelb the test pass again and the issue is corrected.