### PR TITLE
added maxFileSize to formOptions

### DIFF
--- a/config/servers/web.js
+++ b/config/servers/web.js
@@ -66,7 +66,8 @@ exports['default'] = {
         formOptions: {
           uploadDir: os.tmpdir(),
           keepExtensions: false,
-          maxFieldsSize: 1024 * 1024 * 100
+          maxFieldsSize: 1024 * 1024 * 100,
+          maxFileSize: 1024 * 1024 * 1000
         },
         // Should we pad JSON responses with whitespace to make them more human-readable?
         // set to null to disable


### PR DESCRIPTION
allow uploads >200mb after node-formidable v1.2.1 config update:
https://github.com/felixge/node-formidable/pull/464#issuecomment-374898543