### PR TITLE
pre-init doCluster callback before writing to redis

### DIFF
--- a/bin/deploy-docs
+++ b/bin/deploy-docs
@@ -48,7 +48,7 @@ echo 'docs.actionherojs.com' >> gh-pages-branch/CNAME
 
 ## Build other versions
 VERSION_V17=$(git tag --sort=refname | grep v17 | tail -n1)
-build_branch "v17" $VERSION_V17
+build_branch $VERSION_V17 $VERSION_V17
 
 VERSION_V18=$(git tag --sort=refname | grep v18 | tail -n1)
 build_branch $VERSION_V18 $VERSION_V18

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "actionhero",
-  "version": "19.0.2",
+  "version": "19.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
solves https://github.com/actionhero/actionhero/issues/1244

Redis is so fast! Node is so Fast!  It is possible that while `await`ing the write response from redis, that another node got the job and did it already.  If we are waiting for a response, we would miss it!

This PR ensures that there is a response handler/promise before we write to redis, and that we aren't pre-`await`ing it.