### PR TITLE
Wait for chat room members to be removed before destroying room

### DIFF
--- a/initializers/chatRoom.js
+++ b/initializers/chatRoom.js
@@ -241,7 +241,7 @@ class ChatRoom extends ActionHero.Initializer {
         let membersHash = await api.redis.clients.client.hgetall(api.chatRoom.keys.members + room)
 
         for (let id in membersHash) {
-          api.chatRoom.removeMember(id, room, false)
+          await api.chatRoom.removeMember(id, room, false)
         }
 
         await api.redis.clients.client.srem(api.chatRoom.keys.rooms, room)


### PR DESCRIPTION
`api.chatRoom.destroy` doesn't wait for each each member to be
removed before destroying the room. This leads to chat room middleware
being run after deletion and bugs can occur if the `leave` middleware
needs to interact with the room before exiting.

Added `await` keyword to the `removeMember`.