### PR TITLE
Fix loading a locked item

### DIFF
--- a/initializers/cache.js
+++ b/initializers/cache.js
@@ -151,10 +151,10 @@ class Cache extends ActionHero.Initializer {
      */
     api.cache.load = async (key, options) => {
       if (!options) { options = {} }
-            
+
       let lockOk = await api.cache.checkLock(key, options.retry)
       if (lockOk !== true) { throw new Error(api.i18n.localize('actionhero.cache.objectLocked')) }
-      
+
       let cacheObj = await redis.get(api.cache.redisPrefix + key)
       try { cacheObj = JSON.parse(cacheObj) } catch (e) {}
 


### PR DESCRIPTION
An item is loaded from the cache and is eventually old copy, because first is loaded and then is checked for locking. In such a case the locker worker may apply changes to the item during the lock, but we don't receive a fresh copy for the item. This fix is checking for lock first and then tries to load the item.