### PR TITLE
add metadata logging to console logger via default format

### DIFF
--- a/config/logger.js
+++ b/config/logger.js
@@ -13,8 +13,8 @@ function buildConsoleLogger (level = 'info') {
       format: winston.format.combine(
         winston.format.timestamp(),
         winston.format.colorize(),
-        winston.format.printf(msg => {
-          return `${api.id} @ ${msg.timestamp} - ${msg.level}: ${msg.message}`
+        winston.format.printf(info => {
+          return `${api.id} @ ${info.timestamp} - ${info.level}: ${info.message} ${stringifyExtraMessagePropertiesForConsole(info)}`
         })
       ),
       level,
@@ -22,6 +22,20 @@ function buildConsoleLogger (level = 'info') {
       transports: [ new winston.transports.Console() ]
     })
   }
+}
+
+function stringifyExtraMessagePropertiesForConsole (info) {
+  const skpippedProperties = ['message', 'timestamp', 'level']
+  let response = ''
+
+  for (let key in info) {
+    let value = info[key]
+    if (skpippedProperties.includes(key)) { continue }
+    if (value === undefined || value === null) { continue }
+    response += `${key}=${value} `
+  }
+
+  return response
 }
 
 function buildFileLogger (path, level = 'info', maxFiles = undefined, maxsize = 20480) {


### PR DESCRIPTION
Solves https://github.com/actionhero/actionhero/issues/1267

```
192.168.7.192 @ 2018-11-14T06:14:26.814Z - info: [ action @ web ] to=127.0.0.1 action=randomNumber params={"action":"randomNumber","apiVersion":1} duration=0
192.168.7.192 @ 2018-11-14T06:17:33.196Z - info: [ file @ web ] to=127.0.0.1 file={not found} requestedFile=something success=false
192.168.7.192 @ 2018-11-14T06:17:37.972Z - info: [ file @ web ] to=127.0.0.1 file=/Users/evan/PROJECTS/actionhero/actionhero/public/index.html requestedFile=index.html size=5235 duration=8 success=true
```

Now by default, metadata from actions and files is returned to the console logger.  This is accomplished by only a change to the Winston logger config in `./config/logger.js`.  The additional data was always present in the JSON file logger.