### PR TITLE
Adding strict transport security header as a default in web server config

### DIFF
--- a/config/servers/web.js
+++ b/config/servers/web.js
@@ -24,7 +24,8 @@ exports['default'] = {
           'X-Powered-By': api.config.general.serverName,
           'Access-Control-Allow-Origin': '*',
           'Access-Control-Allow-Methods': 'HEAD, GET, POST, PUT, PATCH, DELETE, OPTIONS, TRACE',
-          'Access-Control-Allow-Headers': 'Content-Type'
+          'Access-Control-Allow-Headers': 'Content-Type',
+          'Strict-Transport-Security': 'max-age=31536000; includeSubDomains'
         },
         // Route that actions will be served from; secondary route against this route will be treated as actions,
         //  IE: /api/?action=test == /api/test/


### PR DESCRIPTION
As requested in Slack, adding Strict Transport Security header in the default web http header section.

This means that when a request is made over https, it stores in your browser to always redirect you to the https site for the duration of the max-age even if you type in the http address.