### PR TITLE
Config merge empty objects fix, semantic undefined and null

### DIFF
--- a/__tests__/utils/utils.js
+++ b/__tests__/utils/utils.js
@@ -145,7 +145,6 @@ describe('Utils', () => {
       expect(Z.a).toEqual(1)
       expect(Z.b).toEqual(2)
     })
-
   })
 
   describe('eventLoopDelay', () => {

--- a/__tests__/utils/utils.js
+++ b/__tests__/utils/utils.js
@@ -82,6 +82,9 @@ describe('Utils', () => {
     let B = { b: -2, c: 3 }
     let C = { a: 1, b: { m: 10, n: 11 } }
     let D = { a: 1, b: { n: 111, o: 22, p: {} } }
+    let E = { b: {} }
+    let N = { b: null }
+    let U = { b: undefined }
 
     test('simple', () => {
       let Z = api.utils.hashMerge(A, B)
@@ -105,6 +108,44 @@ describe('Utils', () => {
       expect(Z.b.o).toEqual(22)
       expect(Z.b.p).toEqual({})
     })
+
+    test('empty01', () => {
+      let Z = api.utils.hashMerge(E, D)
+      expect(Z.a).toEqual(1)
+      expect(Z.b.n).toEqual(111)
+      expect(Z.b.o).toEqual(22)
+      expect(Z.b.p).toEqual({})
+    })
+
+    test('empty10', () => {
+      let Z = api.utils.hashMerge(D, E)
+      expect(Z.a).toEqual(1)
+      expect(Z.b.n).toEqual(111)
+      expect(Z.b.o).toEqual(22)
+      expect(Z.b.p).toEqual({})
+    })
+
+    test('chained', () => {
+      let Z = api.utils.hashMerge(api.utils.hashMerge(C, E), D)
+      expect(Z.a).toEqual(1)
+      expect(Z.b.m).toEqual(10)
+      expect(Z.b.n).toEqual(111)
+      expect(Z.b.o).toEqual(22)
+      expect(Z.b.p).toEqual({})
+    })
+
+    test('null', () => {
+      let Z = api.utils.hashMerge(A, N)
+      expect(Z.a).toEqual(1)
+      expect(Z.b).toBeUndefined()
+    })
+
+    test('undefined', () => {
+      let Z = api.utils.hashMerge(A, U)
+      expect(Z.a).toEqual(1)
+      expect(Z.b).toEqual(2)
+    })
+
   })
 
   describe('eventLoopDelay', () => {

--- a/initializers/utils.js
+++ b/initializers/utils.js
@@ -113,7 +113,7 @@ let responses = await api.utils.asyncWaterfall(jobs)
             }
           } else {
             // don't create first term if it is undefined or null
-            if(a[i] === undefined || a[i] === null);
+            if (a[i] === undefined || a[i] === null);
             else c[i] = a[i]
           }
         }
@@ -123,7 +123,7 @@ let responses = await api.utils.asyncWaterfall(jobs)
           // can't be anded into above condition, or empty objects will overwrite and not merge
           if (Object.keys(b[i]).length > 0) c[i] = api.utils.hashMerge(c[i], b[i], arg)
           // make sure empty objects are only created, when no key exists yet
-          else if (! (i in c)) c[i] = {}
+          else if (!(i in c)) c[i] = {}
         } else {
           if (typeof b[i] === 'function') {
             response = b[i](arg)
@@ -134,9 +134,9 @@ let responses = await api.utils.asyncWaterfall(jobs)
             }
           } else {
             // ignore second term if it is undefined
-            if(b[i] === undefined);
+            if (b[i] === undefined);
             // delete second term/key if value is null and it already exists
-            else if (b[i] == null && ( i in c)) delete c[i]
+            else if (b[i] == null && (i in c)) delete c[i]
             // normal assignments for everything else
             else c[i] = b[i]
           }


### PR DESCRIPTION
As discussed in #1283, the fixed merge behavior, where undefined values are ignored and null values trigger deletion of keys.

Also some more test cases.
