### PR TITLE
Extend resque queue connection options from config

### DIFF
--- a/config/tasks.js
+++ b/config/tasks.js
@@ -46,6 +46,9 @@ exports['default'] = {
         queue: null,
         multiWorker: null,
         scheduler: null
+      },
+      connectionOptions: {
+        tasks: {}
       }
     }
   }

--- a/initializers/resque.js
+++ b/initializers/resque.js
@@ -33,7 +33,9 @@ module.exports = class Resque extends ActionHero.Initializer {
       queue: null,
       multiWorker: null,
       scheduler: null,
-      connectionDetails: { redis: api.redis.clients.tasks },
+      connectionDetails: Object.assign({}, api.config.tasks.connectionOptions.tasks, {
+        redis: api.redis.clients.tasks
+      }),
 
       startQueue: async () => {
         let Queue = NodeResque.Queue


### PR DESCRIPTION
Hi,
For some task I need to change namespace for node-resque Queue.Connection. For this I create this PR.
Now this can be done like this:
```
connectionOptions: {
  tasks: {
    namespace: ['app', 'resque'],
  },
```
I can extend the logic to other redis clients(`client`, `subscriber`) if you think it is necessary.