### PR TITLE
task.reEnqueuePeriodicTaskIfException default  is true

### DIFF
--- a/classes/task.js
+++ b/classes/task.js
@@ -56,7 +56,7 @@ module.exports = class SayHello extends Task {
       frequency: 0,
       queue: 'default',
       middleware: [],
-      reEnqueuePeriodicTaskIfException: false
+      reEnqueuePeriodicTaskIfException: true
     }
   }
 

--- a/initializers/tasks.js
+++ b/initializers/tasks.js
@@ -152,7 +152,7 @@ module.exports = class Tasks extends ActionHero.Initializer {
             response = await task.run.apply(task, combinedArgs)
             await api.tasks.enqueueRecurrentTask(taskName)
           } catch (error) {
-            if (task.reEnqueuePeriodicTaskIfException) {
+            if (task.frequency > 0 && task.reEnqueuePeriodicTaskIfException) {
               await api.tasks.enqueueRecurrentTask(taskName)
             }
             throw error


### PR DESCRIPTION
Modification of https://github.com/actionhero/actionhero/pull/1309 so that by default periodic tasks with an exception will still be periodically occurring.  The new option, `task.reEnqueuePeriodicTaskIfException` can de set to `false` to have the task stop recurring on an exception. 