### PR TITLE
Refactor api.log loglevel severity

### DIFF
--- a/classes/process.js
+++ b/classes/process.js
@@ -140,7 +140,7 @@ module.exports = class Process {
           } catch (error) {
             let message = `Exception occured in initializer \`${initializer.name}\` during load`
             try {
-              api.log(message, 'warning', error.toString())
+              api.log(message, 'emerg', error.toString())
             } catch (_error) {
               console.error(message)
             }
@@ -156,7 +156,7 @@ module.exports = class Process {
             await initializer.start()
             api.log(`Started initializer: ${initializer.name}`, 'debug', file)
           } catch (error) {
-            api.log(`Exception occured in initializer: ${initializer.name} during start`, 'warning', error.toString())
+            api.log(`Exception occured in initializer \`${initializer.name}\` during start`, 'emerg', error.toString())
             throw error
           }
         }
@@ -169,7 +169,7 @@ module.exports = class Process {
             await initializer.stop()
             api.log(`Stopped initializer: ${initializer.name}`, 'debug', file)
           } catch (error) {
-            api.log(`Exception occured in initializer: ${initializer.name} during stop`, 'warning', error.toString())
+            api.log(`Exception occured in initializer \`${initializer.name}\` during stop`, 'emerg', error.toString())
             throw error
           }
         }
@@ -208,15 +208,15 @@ module.exports = class Process {
     }
 
     api.running = true
-    api.log('*** Starting ActionHero ***', 'notice')
+    api.log('*** Starting ActionHero ***', 'info')
 
     this.startInitializers.push(() => {
       api.bootTime = new Date().getTime()
       if (this.startCount === 0) {
-        api.log('*** ActionHero Started ***', 'alert')
+        api.log('*** ActionHero Started ***', 'notice')
         this.startCount++
       } else {
-        api.log('*** ActionHero Restarted ***', 'alert')
+        api.log('*** ActionHero Restarted ***', 'notice')
       }
     })
 
@@ -239,8 +239,7 @@ module.exports = class Process {
 
       this.stopInitializers.push(async () => {
         api.pids.clearPidFile()
-        api.log('*** ActionHero Stopped ***', 'alert')
-        api.log('***', 'debug')
+        api.log('*** ActionHero Stopped ***', 'notice')
         delete api.shuttingDown
         // reset initializers to prevent duplicate check on restart
         this.initializers = {}
@@ -284,7 +283,7 @@ module.exports = class Process {
         api.log(`Error with initializer step: ${type}`, 'emerg')
         errors.forEach((error) => { api.log(error.stack, 'emerg') })
       } else {
-        console.error('Error with initializer step: ' + type)
+        console.error(`Error with initializer step: ${type}`)
         errors.forEach((error) => { console.error(error.stack) })
       }
       await api.commands.stop.call(api)

--- a/config/redis.js
+++ b/config/redis.js
@@ -19,7 +19,7 @@ exports['default'] = {
     function retryStrategy (times) {
       if (times === 1) {
         const error = 'Unable to connect to Redis - please check your Redis config!'
-        if (process.env.NODE_ENV === 'test') { console.error(error) } else { api.log(error, 'error') }
+        if (process.env.NODE_ENV === 'test') { console.error(error) } else { api.log(error, 'alert') }
         return 5000
       }
       return Math.min(times * 50, maxBackoff)

--- a/initializers/actions.js
+++ b/initializers/actions.js
@@ -90,7 +90,7 @@ module.exports = class Actions extends ActionHero.Initializer {
 
       const loadMessage = (action) => {
         if (reload) {
-          api.log(`action reloaded: ${action.name} @ v${action.version}, ${fullFilePath}`, 'debug')
+          api.log(`action reloaded: ${action.name} @ v${action.version}, ${fullFilePath}`, 'info')
         } else {
           api.log(`action loaded: ${action.name} @ v${action.version}, ${fullFilePath}`, 'debug')
         }

--- a/initializers/redis.js
+++ b/initializers/redis.js
@@ -146,11 +146,11 @@ await api.redis.publish(payload)
       if (api.config.redis[r].buildNew === true) {
         const args = api.config.redis[r].args
         api.redis.clients[r] = new api.config.redis[r].konstructor(args[0], args[1], args[2]) // eslint-disable-line
-        api.redis.clients[r].on('error', (error) => { api.log(`Redis connection \`${r}\` error`, 'error', error) })
+        api.redis.clients[r].on('error', (error) => { api.log(`Redis connection \`${r}\` error`, 'alert', error) })
         api.redis.clients[r].on('connect', () => { api.log(`Redis connection \`${r}\` connected`, 'debug') })
       } else {
         api.redis.clients[r] = api.config.redis[r].konstructor.apply(null, api.config.redis[r].args)
-        api.redis.clients[r].on('error', (error) => { api.log(`Redis connection \`${r}\` error`, 'error', error) })
+        api.redis.clients[r].on('error', (error) => { api.log(`Redis connection \`${r}\` error`, 'alert', error) })
         api.log(`Redis connection \`${r}\` connected`, 'debug')
       }
 

--- a/initializers/resque.js
+++ b/initializers/resque.js
@@ -76,7 +76,7 @@ module.exports = class Resque extends ActionHero.Initializer {
           api.resque.scheduler.on('poll', () => { api.log('resque scheduler polling', api.resque.schedulerLogging.poll) })
           api.resque.scheduler.on('working_timestamp', (timestamp) => { api.log(`resque scheduler working timestamp ${timestamp}`, api.resque.schedulerLogging.working_timestamp) })
           api.resque.scheduler.on('transferred_job', (timestamp, job) => { api.log(`resque scheduler enqueuing job ${timestamp}`, api.resque.schedulerLogging.transferred_job, job) })
-          api.resque.scheduler.on('master', (state) => { api.log('This node is now the Resque scheduler master') })
+          api.resque.scheduler.on('master', (state) => { api.log('This node is now the Resque scheduler master', 'notice') })
           api.resque.scheduler.on('cleanStuckWorker', (workerName, errorPayload, delta) => { api.log('cleaned stuck worker', 'warning', { workerName, errorPayload, delta }) })
 
           api.resque.scheduler.start()

--- a/initializers/specHelper.js
+++ b/initializers/specHelper.js
@@ -43,7 +43,7 @@ module.exports = class SpecHelper extends ActionHero.Initializer {
       }
 
       start (api) {
-        api.log('loading the testServer', 'warning')
+        api.log('loading the testServer', 'info')
         this.on('connection', (connection) => { this.handleConnection(connection) })
         this.on('actionComplete', (data) => { this.actionComplete(data) })
       }

--- a/initializers/tasks.js
+++ b/initializers/tasks.js
@@ -75,6 +75,7 @@ module.exports = class Tasks extends ActionHero.Initializer {
   }
 
   initialize () {
+
     api.tasks = {
       tasks: {},
       jobs: {},
@@ -106,7 +107,7 @@ module.exports = class Tasks extends ActionHero.Initializer {
 
         api.tasks.tasks[task.name] = task
         api.tasks.jobs[task.name] = api.tasks.jobWrapper(task.name)
-        api.log(`task ${(reload ? '(re)' : '')} loaded: ${task.name}, ${fullFilePath}`, 'debug')
+        api.log(`task ${(reload ? '(re)' : '')} loaded: ${task.name}, ${fullFilePath}`, (reload ? 'info' : 'debug'))
       }
     }
 

--- a/initializers/tasks.js
+++ b/initializers/tasks.js
@@ -75,7 +75,6 @@ module.exports = class Tasks extends ActionHero.Initializer {
   }
 
   initialize () {
-
     api.tasks = {
       tasks: {},
       jobs: {},

--- a/servers/websocket.js
+++ b/servers/websocket.js
@@ -166,8 +166,7 @@ module.exports = class WebSocketServer extends ActionHero.Server {
         fs.writeFileSync(clientJSFullPath + '.min.js', this.renderClientJS(true))
         api.log(`wrote ${clientJSFullPath}.min.js`, 'debug')
       } catch (e) {
-        api.log('Cannot write client-side JS for websocket server:', 'warning')
-        api.log(e, 'warning')
+        api.log('Cannot write client-side JS for websocket server:', 'warning', e)
         throw e
       }
     }


### PR DESCRIPTION
Preface:
ActionHero uses the winston syslog loglevels.
The syslog protocol (RFC 5424) knows 8 severities levels:

Code | Level | Description
-- | -- | --
0 | Emergency | system is unusable
1 | Alert | action must be taken immediately
2 | Critical | critical conditions
3 | Error | error conditions
4 | Warning | warning conditions
5 | Notice | normal but significant condition
6 | Informational | informational messages
7 | Debug | debug-level messages

Issue:
I noticed that ActionHero logs some messages with severities worthy of discussion. For example, when I define an error logger in winston, the error log will grow with `*** ActionHero Started ***` and `*** ActionHero Stopped ***` log entries because they are logged with severity `alert`. I think I don't have to take immediate action just because ActionHero started and I feel like it shouldn't be logged in an error log. I took the oportunity and went through all api.log calls to check on their severity.

I would purpose the following changes, each of them entirely open for discussion:

File | Log cause | Previous level | Proposed level | Reason
-- | -- | -- | -- | --
`classes/process.js` | Initializer exception | warning | emerg | ActionHero will fail to start
^ | ActionHero starting | notice | info | Only indicating begin of start process
^ | ActionHero start/restart/stopped | alert | notice | Normal condition with significance
`config/redis.js` | Redis connection first retry | error | alert | If redis connection retries continue to fail (if no immediate action is taken), ActionHero will fail to start 
`initializers/actions.js` | Action reloaded | debug | info | Should get informed about reloads (not initial loads) to make obvious which code version is currently loaded in developmentMode
`initializers/redis.js` | Redis connection further retries | error | alert | If redis connection retries continue to fail (if no immediate action is taken), ActionHero will fail to start 
`initializers/resque.js` | Node elected as new resque master | info | notice | Normal but significant condition
`initializers/specHelper.js` | Loading testServer | warning | info | Nothing to warn about, informational character
`initializers/tasks.js` | Tasks reloaded | debug | info | Should get informed about reloads (not initial loads) to make obvious which code version is currently loaded in developmentMode