### PR TITLE
create tests for actions and tasks when generating via CLI

### DIFF
--- a/__tests__/core/cli.js
+++ b/__tests__/core/cli.js
@@ -124,7 +124,7 @@ describe('Core: CLI', () => {
         'locales/en.json',
         'tasks',
         '__tests__',
-        '__tests__/example.js',
+        '__tests__/actions/status.js',
         '.gitignore',
         'boot.js'
       ].forEach((f) => {

--- a/__tests__/core/cli.js
+++ b/__tests__/core/cli.js
@@ -40,8 +40,7 @@ const doCommand = async (command, useCwd) => {
     pid = cmd.pid
 
     cmd.on('close', (exitCode) => {
-      // running jest in a sub-shell returns the output as stderr, so we need to filter it
-      if ((stderr.length > 0 && stderr.indexOf('✓') < 0) || exitCode !== 0) {
+      if (stderr.length > 0 || exitCode !== 0) {
         const error = new Error(stderr)
         error.stderr = stderr
         error.stdout = stdout
@@ -233,7 +232,12 @@ describe('Core: CLI', () => {
     })
 
     test('can call npm test in the new project and not fail', async () => {
-      await doCommand('npm test')
+      // jest writes to stderr for some reason, so we need to test for the exit code here
+      try {
+        await doCommand('npm test')
+      } catch (error) {
+        if (error.exitCode !== 0) { throw error }
+      }
     }, 120000)
 
     describe('can run a single server', () => {

--- a/__tests__/core/cli.js
+++ b/__tests__/core/cli.js
@@ -158,18 +158,24 @@ describe('Core: CLI', () => {
 
     test('can generate an action', async () => {
       await doCommand(`${binary} generate action --name=myAction --description=my_description`)
-      const data = String(fs.readFileSync(`${testDir}/actions/myAction.js`))
-      expect(data).toMatch(/this.name = 'myAction'/)
-      expect(data).toMatch(/this.description = 'my_description'/)
+      const actionData = String(fs.readFileSync(`${testDir}/actions/myAction.js`))
+      expect(actionData).toMatch(/this.name = 'myAction'/)
+      expect(actionData).toMatch(/this.description = 'my_description'/)
+
+      const testData = String(fs.readFileSync(`${testDir}/__tests__/actions/myAction.js`))
+      expect(testData).toMatch("describe('myAction'")
     })
 
     test('can generate a task', async () => {
       await doCommand(`${binary} generate task --name=myTask --description=my_description --queue=my_queue --frequency=12345`)
-      const data = String(fs.readFileSync(`${testDir}/tasks/myTask.js`))
-      expect(data).toMatch(/this.name = 'myTask'/)
-      expect(data).toMatch(/this.description = 'my_description'/)
-      expect(data).toMatch(/this.queue = 'my_queue'/)
-      expect(data).toMatch(/this.frequency = 12345/)
+      const taskData = String(fs.readFileSync(`${testDir}/tasks/myTask.js`))
+      expect(taskData).toMatch(/this.name = 'myTask'/)
+      expect(taskData).toMatch(/this.description = 'my_description'/)
+      expect(taskData).toMatch(/this.queue = 'my_queue'/)
+      expect(taskData).toMatch(/this.frequency = 12345/)
+
+      const testData = String(fs.readFileSync(`${testDir}/__tests__/tasks/myTask.js`))
+      expect(testData).toMatch("describe('myTask'")
     })
 
     test('can generate a CLI command', async () => {

--- a/bin/methods/generate.js
+++ b/bin/methods/generate.js
@@ -77,7 +77,9 @@ module.exports = class Generate extends ActionHero.CLI {
       '/public/css',
       '/public/logo',
       '/tasks',
-      '/__tests__'
+      '/__tests__',
+      '/__tests__/actions',
+      '/__tests__/tasks'
     ].forEach((dir) => {
       try {
         const message = api.utils.createDirSafely(api.projectRoot + dir)
@@ -108,7 +110,7 @@ module.exports = class Generate extends ActionHero.CLI {
       '/public/css/cosmo.css': 'publicCss',
       '/public/logo/actionhero.png': 'publicLogo',
       '/README.md': 'readmeMd',
-      '/__tests__/example.js': 'exampleTest',
+      '/__tests__/actions/status.js': 'exampleTest',
       '/locales/en.json': 'enLocale',
       '/.gitignore': 'gitignore',
       '/boot.js': 'bootJs'

--- a/bin/methods/generate/action.js
+++ b/bin/methods/generate/action.js
@@ -18,18 +18,23 @@ module.exports = class GenerateAction extends ActionHero.CLI {
   }
 
   run ({ params }) {
-    let template = fs.readFileSync(path.join(__dirname, '/../../templates/action.js'))
-    template = String(template);
+    let actionTemplate = fs.readFileSync(path.join(__dirname, '../../templates/action.js'))
+    actionTemplate = String(actionTemplate)
+    let testTemplate = fs.readFileSync(path.join(__dirname, '/../../templates/test/action.js'))
+    testTemplate = String(testTemplate);
 
     [
       'name',
       'description'
     ].forEach((v) => {
       const regex = new RegExp('%%' + v + '%%', 'g')
-      template = template.replace(regex, params[v])
+      actionTemplate = actionTemplate.replace(regex, params[v])
+      testTemplate = testTemplate.replace(regex, params[v])
     })
 
-    const message = api.utils.createFileSafely(api.config.general.paths.action[0] + '/' + params.name + '.js', template)
+    let message = api.utils.createFileSafely(api.config.general.paths.action[0] + '/' + params.name + '.js', actionTemplate)
+    console.info(message)
+    message = api.utils.createFileSafely(api.config.general.paths.test[0] + '/actions/' + params.name + '.js', testTemplate)
     console.info(message)
 
     return true

--- a/bin/methods/generate/task.js
+++ b/bin/methods/generate/task.js
@@ -20,8 +20,10 @@ module.exports = class GenerateTask extends ActionHero.CLI {
   }
 
   run ({ params }) {
-    let template = fs.readFileSync(path.join(__dirname, '/../../templates/task.js'))
-    template = String(template);
+    let taskTemplate = fs.readFileSync(path.join(__dirname, '/../../templates/task.js'))
+    taskTemplate = String(taskTemplate)
+    let testTemplate = fs.readFileSync(path.join(__dirname, '/../../templates/test/task.js'))
+    testTemplate = String(testTemplate);
 
     [
       'name',
@@ -30,11 +32,14 @@ module.exports = class GenerateTask extends ActionHero.CLI {
       'frequency'
     ].forEach((v) => {
       const regex = new RegExp('%%' + v + '%%', 'g')
-      template = template.replace(regex, params[v])
+      taskTemplate = taskTemplate.replace(regex, params[v])
+      testTemplate = testTemplate.replace(regex, params[v])
     })
 
-    const message = api.utils.createFileSafely(api.config.general.paths.task[0] + '/' + params.name + '.js', template)
-    console.log(message)
+    let message = api.utils.createFileSafely(api.config.general.paths.task[0] + '/' + params.name + '.js', taskTemplate)
+    console.info(message)
+    message = api.utils.createFileSafely(api.config.general.paths.test[0] + '/tasks/' + params.name + '.js', testTemplate)
+    console.info(message)
 
     return true
   }

--- a/bin/templates/action.js
+++ b/bin/templates/action.js
@@ -1,7 +1,7 @@
 'use strict'
-const ActionHero = require('actionhero')
+const { Action } = require('actionhero')
 
-module.exports = class MyAction extends ActionHero.Action {
+module.exports = class MyAction extends Action {
   constructor () {
     super()
     this.name = '%%name%%'
@@ -11,5 +11,6 @@ module.exports = class MyAction extends ActionHero.Action {
 
   async run (data) {
     // your logic here
+    data.response.ok = true
   }
 }

--- a/bin/templates/cli.js
+++ b/bin/templates/cli.js
@@ -1,7 +1,7 @@
 'use strict'
-const ActionHero = require('actionhero')
+const { CLI } = require('actionhero')
 
-module.exports = class MyCLICommand extends ActionHero.CLI {
+module.exports = class MyCLICommand extends CLI {
   constructor () {
     super()
     this.name = '%%name%%'

--- a/bin/templates/initializer.js
+++ b/bin/templates/initializer.js
@@ -1,7 +1,7 @@
 'use strict'
-const ActionHero = require('actionhero')
+const { Initializer, api } = require('actionhero')
 
-module.exports = class MyInitializer extends ActionHero.Initializer {
+module.exports = class MyInitializer extends Initializer {
   constructor () {
     super()
     this.name = '%%name%%'
@@ -11,7 +11,7 @@ module.exports = class MyInitializer extends ActionHero.Initializer {
   }
 
   async initialize () {
-    ActionHero.api['%%name%%'] = {} //eslint-disable-line
+    api['%%name%%'] = {} //eslint-disable-line
   }
 
   async start () {}

--- a/bin/templates/server.js
+++ b/bin/templates/server.js
@@ -1,7 +1,7 @@
 'use strict'
-const ActionHero = require('actionhero')
+const { Server } = require('actionhero')
 
-module.exports = class MyServer extends ActionHero.Server {
+module.exports = class MyServer extends Server {
   constructor () {
     super()
     this.type = '%%name%%'

--- a/bin/templates/test/action.js
+++ b/bin/templates/test/action.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const ActionHero = require('actionhero')
+const actionhero = new ActionHero.Process()
+let api
+
+describe('Action', () => {
+  describe('%%name%%', () => {
+    beforeAll(async () => { api = await actionhero.start() })
+    afterAll(async () => { await actionhero.stop() })
+
+    test('returns OK', async () => {
+      const { ok } = await api.specHelper.runAction('%%name%%')
+      expect(ok).toEqual(true)
+    })
+  })
+})

--- a/bin/templates/test/task.js
+++ b/bin/templates/test/task.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const ActionHero = require('actionhero')
+const actionhero = new ActionHero.Process()
+let api
+
+describe('Task', () => {
+  describe('%%name%%', () => {
+    beforeAll(async () => { api = await actionhero.start() })
+    afterAll(async () => { await actionhero.stop() })
+
+    beforeEach(async () => {
+      await api.resque.queue.connection.redis.flushdb()
+    })
+
+    test('can be enqueued', async () => {
+      await api.tasks.enqueue('%%name%%', {})
+      const found = await api.specHelper.findEnqueuedTasks('%%name%%')
+      expect(found.length).toEqual(1)
+      expect(found[0].timestamp).toBeNull()
+    })
+  })
+})

--- a/config/api.js
+++ b/config/api.js
@@ -60,7 +60,8 @@ exports.default = {
         cli: [path.join(__dirname, '/../bin')],
         initializer: [path.join(__dirname, '/../initializers')],
         plugin: [path.join(__dirname, '/../node_modules')],
-        locale: [path.join(__dirname, '/../locales')]
+        locale: [path.join(__dirname, '/../locales')],
+        test: [path.join(__dirname, '/../__tests__')]
       },
       // hash containing chat rooms you wish to be created at server boot
       startingChatRooms: {


### PR DESCRIPTION
Completes https://github.com/actionhero/actionhero/issues/1005

When generating a new `action` or `task` via the CLI, a template test will also now be creates in `__tests__`.  This will help encourage better testing of your actionhero projects.  Of course, you can always delete the test files if you don't want it.

Adds `api.config.general.paths.test` as setting in `./config/api.js` which defaults to `[path.join(__dirname, '/../__tests__')]`