### PR TITLE
Always prefer actionhero in node_modules

### DIFF
--- a/config/api.js
+++ b/config/api.js
@@ -51,17 +51,17 @@ exports.default = {
       cliIncludeInternal: true,
       // configuration for your actionhero project structure
       paths: {
-        action: [path.join(__dirname, '/../actions')],
-        task: [path.join(__dirname, '/../tasks')],
-        public: [path.join(__dirname, '/../public')],
-        pid: [path.join(__dirname, '/../pids')],
-        log: [path.join(__dirname, '/../log')],
-        server: [path.join(__dirname, '/../servers')],
-        cli: [path.join(__dirname, '/../bin')],
-        initializer: [path.join(__dirname, '/../initializers')],
-        plugin: [path.join(__dirname, '/../node_modules')],
-        locale: [path.join(__dirname, '/../locales')],
-        test: [path.join(__dirname, '/../__tests__')]
+        action: [path.join(process.cwd(), 'actions')],
+        task: [path.join(process.cwd(), 'tasks')],
+        public: [path.join(process.cwd(), 'public')],
+        pid: [path.join(process.cwd(), 'pids')],
+        log: [path.join(process.cwd(), 'log')],
+        server: [path.join(process.cwd(), 'servers')],
+        cli: [path.join(process.cwd(), 'bin')],
+        initializer: [path.join(process.cwd(), 'initializers')],
+        plugin: [path.join(process.cwd(), 'node_modules')],
+        locale: [path.join(process.cwd(), 'locales')],
+        test: [path.join(process.cwd(), '__tests__')]
       },
       // hash containing chat rooms you wish to be created at server boot
       startingChatRooms: {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const fs = require('fs');
+const fs = require('fs')
 
 /**
  * The top-level for all actionhero methods which can be used within your project.

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-const path = require('path');
+const path = require('path')
+const fs = require('fs');
 
 /**
  * The top-level for all actionhero methods which can be used within your project.
@@ -36,6 +37,15 @@ const path = require('path');
  * @class ActionHero
  */
 
+function requireRelative (klass, file) {
+  let fullPath = path.join(process.cwd(), 'node_modules', 'actionhero', 'classes', file)
+  if (!fs.existsSync(fullPath)) {
+    fullPath = path.join(__dirname, 'classes', file)
+  }
+
+  exports[klass] = require(fullPath)
+}
+
 [
   { klass: 'Process', file: 'process.js' },
   { klass: 'Action', file: 'action.js' },
@@ -46,7 +56,7 @@ const path = require('path');
   { klass: 'ActionProcessor', file: 'actionProcessor.js' },
   { klass: 'Connection', file: 'connection.js' }
 ].forEach(({ klass, file }) => {
-  exports[klass] = require(path.join(__dirname, 'classes', file))
+  requireRelative(klass, file)
 })
 
 exports.api = {}


### PR DESCRIPTION
Related to https://github.com/actionhero/ah-swagger-plugin/pull/6

If we change how Actionhero loads itself to *always* prefer components in `node_modules` relative to the `cwd` (current working directory):

**Pros**
* There is no change to the behavior or a normal actionhero project
* Globally installed Actionhero (`npm install -g actionhero`) is now resistant to minor version changes between projects
* Allows plugins to install a version of actionhero as a `devDependancy`, and for us to boot the project and not have conflicting paths to source actionhero from.  You can now just `npm start` (`./node_modules/.bin/actionhero`) in your plugins to start a server to run your plugins

**Cons**
* If you start actoinhero from a dameon (like `forever`) without first `cd`-ing to the proper directory first things might not work? 
* Slightly slower boot time (as we are checking if files exist before trying to load them)
* Gets weird with yarn/lerna workspaces
* ? -> Add some in the comments!