### PR TITLE
Allow funding support of actionhero

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: [evantahler]


### PR DESCRIPTION
This PR adds a `FUNDING.yml` to actionhero.  [Learn more here](https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository)

This will allow folks to sponsor to the maintainers/creators of Actionhero via Github Sponsorships. 

To start, this list only includes @evantahler.  We will need to come up with a policy for adding contributors to this list. 