### PR TITLE
Allow for a session object in actionProcessor and Action data

### DIFF
--- a/src/classes/actionProcessor.ts
+++ b/src/classes/actionProcessor.ts
@@ -25,7 +25,7 @@ export class ActionProcessor {
   actionStatus: string | Error;
 
   // allow for setting of any value via middleware
-  session: { [key: string]: any };
+  session: any;
 
   constructor(connection: Connection) {
     /// Only in files required by `index.js` do we need to delay the loading of the API object

--- a/src/classes/actionProcessor.ts
+++ b/src/classes/actionProcessor.ts
@@ -24,6 +24,9 @@ export class ActionProcessor {
   duration: number;
   actionStatus: string | Error;
 
+  // allow for setting of any value via middleware
+  session: { [key: string]: any };
+
   constructor(connection: Connection) {
     /// Only in files required by `index.js` do we need to delay the loading of the API object
     // This is due to cyclical require issues
@@ -43,6 +46,7 @@ export class ActionProcessor {
     this.response = {};
     this.duration = null;
     this.actionStatus = null;
+    this.session = {};
   }
 
   private incrementTotalActions(count = 1) {

--- a/src/classes/process.ts
+++ b/src/classes/process.ts
@@ -139,7 +139,13 @@ export class Process {
       const file = path.normalize(f);
       delete require.cache[require.resolve(file)];
 
-      const exportedClasses = require(file);
+      let exportedClasses = require(file);
+
+      // allow for old-js style single default exports
+      if (typeof exportedClasses === "function") {
+        exportedClasses = { default: exportedClasses };
+      }
+
       if (Object.keys(exportedClasses).length === 0) {
         this.fatalError(
           new Error(`no exported intializers found in ${file}`),

--- a/tutorials/actions.md
+++ b/tutorials/actions.md
@@ -361,6 +361,7 @@ data = {
   params: { action: 'randomNumber', apiVersion: 1 },
   actionStartTime: 123,
   response: {},
+  session: {}
 }
 ```
 


### PR DESCRIPTION
Now with Typescript, you'll get an error if you try to set arbitrary properties on the `data` object either within an action or middleware.  We need a place to pass data from the middleware to the action.