### PR TITLE
Use --no-deps in ts-node-dev

### DIFF
--- a/templates/package.json.template
+++ b/templates/package.json.template
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "postinstall": "npm run build",
-    "dev": "ts-node-dev --transpile-only ./node_modules/.bin/actionhero start",
+    "dev": "ts-node-dev --no-deps --transpile-only ./node_modules/.bin/actionhero start",
     "start": "actionhero start",
     "actionhero": "actionhero",
     "test": "jest",


### PR DESCRIPTION
Right now ts-node-dev watches all direct dependencies in node_modules which is unnecessary. [Adding --no-deps](https://github.com/whitecolor/ts-node-dev/issues/51#issuecomment-512096067) makes server restarts *significantly faster*.  People shouldn't be modifying node_modules directly anyway and server restarts anyway when package.json changes, so I think this is a good thing to have by default.