### PR TITLE
remove --daemon option to start actionhero

### DIFF
--- a/src/bin/actionhero.ts
+++ b/src/bin/actionhero.ts
@@ -176,33 +176,14 @@ const projectRoot = determineProjectRoot();
         );
         console.error("run `actionhero help` to learn more");
         setTimeout(process.exit, 500, 1);
+      } else if (Object.keys(ExportedClasses).length > 1) {
+        throw new Error("actionhero CLI files should only export one method");
       } else {
-        if (optimist.argv.daemon) {
-          const newArgs: Array<string> = process.argv.splice(2);
-          for (const i in newArgs) {
-            if (newArgs[i].indexOf("--daemon") >= 0) {
-              newArgs.splice(parseInt(i), 1);
-            }
-          }
-          newArgs.push("--isDaemon=true");
-          const command = path.normalize(actionheroRoot + "/bin/actionhero");
-          const child = spawn(command, newArgs, {
-            detached: true,
-            cwd: process.cwd(),
-            env: process.env,
-            stdio: "ignore"
-          });
-          console.log(`spawned child process with pid ${child.pid}`, "notice");
-          process.nextTick(process.exit);
-        } else if (Object.keys(ExportedClasses).length > 1) {
-          throw new Error("actionhero CLI files should only export one method");
-        } else {
-          const runner = new ExportedClasses[Object.keys(ExportedClasses)[0]]();
-          const params = formatParams(runner);
-          const toStop = await runner.run({ params: params });
-          if (toStop || toStop === null || toStop === undefined) {
-            setTimeout(process.exit, 500, 0);
-          }
+        const runner = new ExportedClasses[Object.keys(ExportedClasses)[0]]();
+        const params = formatParams(runner);
+        const toStop = await runner.run({ params: params });
+        if (toStop || toStop === null || toStop === undefined) {
+          setTimeout(process.exit, 500, 0);
         }
       }
     } catch (error) {

--- a/src/bin/methods/start.ts
+++ b/src/bin/methods/start.ts
@@ -6,14 +6,14 @@ import { api, CLI } from "./../../index";
 export class Start extends CLI {
   state: string;
   shutdownTimeout: number;
-  checkForInernalStopTimer: NodeJS.Timeout;
+  checkForInternalStopTimer: NodeJS.Timeout;
 
   constructor() {
     super();
     this.name = "start";
     this.description = "start this ActionHero server";
     this.example =
-      "actionhero start --config=[/path/to/config] --title=[processTitle] --daemon";
+      "actionhero start --config=[/path/to/config] --title=[processTitle]";
     this.inputs = {
       config: {
         required: false,
@@ -24,10 +24,6 @@ export class Start extends CLI {
         required: false,
         note:
           "process title to use for ActionHero's ID, ps, log, and pidFile defaults. Must be unique for each member of the cluster. You can also use ENV[ACTIONHERO_TITLE]. Process renaming does not work on OSX/Windows"
-      },
-      daemon: {
-        required: false,
-        note: "to fork and run as a new background process defaults to false"
       }
     };
 
@@ -52,7 +48,7 @@ export class Start extends CLI {
     await api.commands.start();
     this.state = "started";
     this.sendState();
-    this.checkForInernalStop();
+    this.checkForInternalStop();
   }
 
   async stopServer() {
@@ -84,14 +80,14 @@ export class Start extends CLI {
     process.exit();
   }
 
-  checkForInernalStop() {
-    // check for an internal stop which doesn't close the processs
-    clearTimeout(this.checkForInernalStopTimer);
+  checkForInternalStop() {
+    // check for an internal stop which doesn't close the process
+    clearTimeout(this.checkForInternalStopTimer);
     if (api.running !== true && this.state === "started") {
       process.exit(0);
     }
-    this.checkForInernalStopTimer = setTimeout(() => {
-      this.checkForInernalStop();
+    this.checkForInternalStopTimer = setTimeout(() => {
+      this.checkForInternalStop();
     }, this.shutdownTimeout);
   }
 

--- a/src/bin/methods/start/cluster.ts
+++ b/src/bin/methods/start/cluster.ts
@@ -15,8 +15,6 @@ import { config, id, CLI } from "../../../index";
  *   -- HTTP/HTTPS/TCP clients will be allowed to finish the action they are working on before the server goes down
  * - TTOU and TTIN signals to subtract/add workers
  * - TCP, HTTP(S), and Web-socket clients will all be shared across the cluster
- * - Can be run as a daemon or in-console
- *   -- Simple Daemon: "actionhero start cluster --daemon"
  * * Setting process titles does not work on windows or OSX
  * This tool was heavily inspired by Ruby Unicorns [[ http://unicorn.bogomips.org/ ]]
  */
@@ -26,7 +24,7 @@ export class StartCluster extends CLI {
     this.name = "start cluster";
     this.description = "start an actionhero cluster";
     this.example =
-      "actionhero start cluster --workers=[numWorkers] --workerTitlePrefix=[title] --daemon";
+      "actionhero start cluster --workers=[numWorkers] --workerTitlePrefix=[title]";
     this.inputs = {
       workers: {
         required: true,
@@ -41,10 +39,6 @@ export class StartCluster extends CLI {
       workerTitlePrefix: {
         required: true,
         default: "actionhero-worker-"
-      },
-      daemon: {
-        required: false,
-        note: "to fork and run as a new background process defaults to false"
       },
       silent: { required: false }
     };


### PR DESCRIPTION
With so many other options to run node.js processes, like [PM2](https://pm2.keymetrics.io/) or your OS's background process manager (ie [`systemd`](https://tibbo.com/linux/nodejs/service-file.html)), we have removed the `--daemon` option from Actionhero