### PR TITLE
specHelper#deleteEnqueuedTasks

### DIFF
--- a/src/modules/specHelper.ts
+++ b/src/modules/specHelper.ts
@@ -131,4 +131,16 @@ export namespace specHelper {
 
     return found;
   }
+
+  /**
+   * Delete all enqueued instances of a task, both in all the normal queues and all of the delayed queues
+   */
+  export async function deleteEnqueuedTasks(taskName: string, params: {}) {
+    const queues = await api.resque.queue.queues();
+    for (const i in queues) {
+      const q = queues[i];
+      await api.resque.queue.del(q, taskName, [params]);
+      await api.resque.queue.delDelayed(q, taskName, [params]);
+    }
+  }
 }


### PR DESCRIPTION
Adds a helper method `specHelper#deleteEnqueuedTasks` which can be used to remove all tasks in your test.

```ts
await task.enqueue("testTask", { a: 1 });
await task.enqueueAt(10, "testTask", { a: 1 });

// will delete tasks in both the normal and delayed queues
await specHelper.deleteEnqueuedTasks("testTask", { a: 1 });

const foundTasks = await specHelper.findEnqueuedTasks("testTask");
expect(foundTasks.length).toBe(0);
```