### PR TITLE
log task durations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "actionhero",
-  "version": "21.0.15",
+  "version": "21.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5235,9 +5235,9 @@
       }
     },
     "node-resque": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/node-resque/-/node-resque-6.0.8.tgz",
-      "integrity": "sha512-QyeD6BVz0THy0KarQFRD3Jwnd4haz2pn/ZQOABz8T6WxBNmva1Bxst9B8ts/YY2N4G0TVmd1EPmreSvSIUp6mQ==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/node-resque/-/node-resque-6.0.9.tgz",
+      "integrity": "sha512-KohIVx6FUe6DIxlDWMQmg6vS2FvKKc+bJNeIptNYydfU9L6Vtvl2MIOzlrMvNjc5MP0tlGRIK//CsY/8VPBohA==",
       "requires": {
         "@types/ioredis": "^4.14.3",
         "@types/node": "^13.1.7",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ioredis": "^4.14.1",
     "is-running": "^2.1.0",
     "mime": "^2.4.4",
-    "node-resque": "^6.0.8",
+    "node-resque": "^6.0.9",
     "optimist": "^0.6.1",
     "primus": "^7.3.4",
     "qs": "^6.9.1",

--- a/src/initializers/resque.ts
+++ b/src/initializers/resque.ts
@@ -193,7 +193,7 @@ export class Resque extends Initializer {
           "reEnqueue",
           (workerId, queue, job: JobEmit, plugin) => {
             log(
-              "[ worker ] reEnqueue job",
+              "[ worker ] reEnqueue task",
               api.resque.workerLogging.reEnqueue,
               {
                 workerId,
@@ -222,17 +222,18 @@ export class Resque extends Initializer {
 
         api.resque.multiWorker.on(
           "success",
-          (workerId, queue, job: JobEmit, result) => {
+          (workerId, queue, job: JobEmit, result, duration) => {
             const payload = {
               workerId,
               class: job.class,
               queue: job.queue,
               args: JSON.stringify(this.filterTaskParams(job.args[0])),
-              result
+              result,
+              duration
             };
 
             log(
-              "[ worker ] job success",
+              "[ worker ] task success",
               api.resque.workerLogging.success,
               payload
             );


### PR DESCRIPTION
When a task is complete, log how long it took in ms.

```
192.168.7.33 @ 2020-02-17T00:01:47.561Z - info: [ worker ] task success workerId=1 class=hello queue=default args={} duration=1007
```