### PR TITLE
Check the lock when cache.get() 2x: before reading and before writing

### DIFF
--- a/src/modules/cache.ts
+++ b/src/modules/cache.ts
@@ -146,6 +146,12 @@ export namespace cache {
     options: CacheOptions = {}
   ): Promise<CacheObject> {
     let cacheObj: CacheObject;
+
+    let lockOk = await cache.checkLock(key, options.retry);
+    if (lockOk !== true) {
+      throw new Error(i18n.localize("actionhero.cache.objectLocked"));
+    }
+
     let cachedStringifiedObjet = await client().get(`${redisPrefix}${key}`);
     try {
       cacheObj = JSON.parse(cachedStringifiedObjet);
@@ -177,7 +183,7 @@ export namespace cache {
       }
     }
 
-    const lockOk = await cache.checkLock(key, options.retry);
+    lockOk = await cache.checkLock(key, options.retry);
     if (lockOk !== true) {
       throw new Error(i18n.localize("actionhero.cache.objectLocked"));
     }


### PR DESCRIPTION
Reimplementing https://github.com/actionhero/actionhero/pull/1265

--- 
From the original PR, via @cecofreeman

An item is loaded from the cache and is eventually old copy, because first is loaded and then is checked for locking. In such a case the locker worker may apply changes to the item during the lock, but we don't receive a fresh copy for the item. This fix is checking for lock first and then tries to load the item.

