### PR TITLE
Better Server Shutdown

### DIFF
--- a/src/classes/process.ts
+++ b/src/classes/process.ts
@@ -325,7 +325,7 @@ export class Process {
    * Register listeners for process signals and uncaught exceptions & rejections.
    * Try to gracefully shut down when signaled to do so
    */
-  registerProcessSignals(stopCallback: (exitCode?: number) => {}) {
+  registerProcessSignals(stopCallback?: (exitCode?: number) => {}) {
     const timeout = process.env.ACTIONHERO_SHUTDOWN_TIMEOUT
       ? parseInt(process.env.ACTIONHERO_SHUTDOWN_TIMEOUT)
       : 1000 * 30;

--- a/src/classes/process.ts
+++ b/src/classes/process.ts
@@ -341,19 +341,23 @@ export class Process {
 
     // handle errors & rejections
     process.once("uncaughtException", async (error: Error) => {
-      log(error.stack, "fatal");
-      let timer = awaitHardStop();
-      await this.stop();
-      clearTimeout(timer);
-      stopCallback(1);
+      log(`UNCAUGHT EXCEPTION: ` + error.stack, "fatal");
+      if (!this.shuttingDown === true) {
+        let timer = awaitHardStop();
+        await this.stop();
+        clearTimeout(timer);
+        stopCallback(1);
+      }
     });
 
     process.once("unhandledRejection", async (rejection: Error) => {
-      log(rejection.stack, "fatal");
-      let timer = awaitHardStop();
-      await this.stop();
-      clearTimeout(timer);
-      stopCallback(1);
+      log(`UNHANDLED REJECTION: ` + rejection.stack, "fatal");
+      if (!this.shuttingDown === true) {
+        let timer = awaitHardStop();
+        await this.stop();
+        clearTimeout(timer);
+        stopCallback(1);
+      }
     });
 
     // handle signals

--- a/src/classes/process.ts
+++ b/src/classes/process.ts
@@ -325,11 +325,12 @@ export class Process {
    * Register listeners for process signals and uncaught exceptions & rejections.
    * Try to gracefully shut down when signaled to do so
    */
-  registerProcessSignals() {
+  registerProcessSignals(stopCallback: (exitCode?: number) => {}) {
+    const timeout = process.env.ACTIONHERO_SHUTDOWN_TIMEOUT
+      ? parseInt(process.env.ACTIONHERO_SHUTDOWN_TIMEOUT)
+      : 1000 * 30;
+
     function awaitHardStop() {
-      const timeout = process.env.ACTIONHERO_SHUTDOWN_TIMEOUT
-        ? parseInt(process.env.ACTIONHERO_SHUTDOWN_TIMEOUT)
-        : 1000 * 30;
       return setTimeout(() => {
         console.error(
           `Process did not terminate within ${timeout}ms. Stopping now!`
@@ -339,14 +340,20 @@ export class Process {
     }
 
     // handle errors & rejections
-    process.on("uncaughtException", (error: Error) => {
+    process.once("uncaughtException", async (error: Error) => {
       log(error.stack, "fatal");
-      process.nextTick(process.exit(1));
+      let timer = awaitHardStop();
+      await this.stop();
+      clearTimeout(timer);
+      stopCallback(1);
     });
 
-    process.on("unhandledRejection", (rejection: Error) => {
+    process.once("unhandledRejection", async (rejection: Error) => {
       log(rejection.stack, "fatal");
-      process.nextTick(process.exit(1));
+      let timer = awaitHardStop();
+      await this.stop();
+      clearTimeout(timer);
+      stopCallback(1);
     });
 
     // handle signals
@@ -355,6 +362,7 @@ export class Process {
       let timer = awaitHardStop();
       await this.stop();
       clearTimeout(timer);
+      stopCallback(0);
     });
 
     process.on("SIGTERM", async () => {
@@ -362,6 +370,7 @@ export class Process {
       let timer = awaitHardStop();
       await this.stop();
       clearTimeout(timer);
+      stopCallback(0);
     });
 
     process.on("SIGUSR2", async () => {

--- a/src/classes/process.ts
+++ b/src/classes/process.ts
@@ -325,7 +325,7 @@ export class Process {
    * Register listeners for process signals and uncaught exceptions & rejections.
    * Try to gracefully shut down when signaled to do so
    */
-  registerProcessSignals(stopCallback?: (exitCode?: number) => {}) {
+  registerProcessSignals(stopCallback = (exitCode?: number) => {}) {
     const timeout = process.env.ACTIONHERO_SHUTDOWN_TIMEOUT
       ? parseInt(process.env.ACTIONHERO_SHUTDOWN_TIMEOUT)
       : 1000 * 30;

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,9 @@ async function main() {
   const app = new Process();
 
   // handle unix signals and uncaught exceptions & rejections
-  app.registerProcessSignals();
+  app.registerProcessSignals(exitCode => {
+    process.exit(exitCode);
+  });
 
   // start the app!
   // you can pass custom configuration to the process as needed

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,9 +8,10 @@ async function main() {
   const app = new Process();
 
   // handle unix signals and uncaught exceptions & rejections
-  app.registerProcessSignals(exitCode => {
-    process.exit(exitCode);
-  });
+  // app.registerProcessSignals(exitCode => {
+  //   process.exit(exitCode);
+  // });
+  app.registerProcessSignals();
 
   // start the app!
   // you can pass custom configuration to the process as needed

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,10 +8,9 @@ async function main() {
   const app = new Process();
 
   // handle unix signals and uncaught exceptions & rejections
-  // app.registerProcessSignals(exitCode => {
-  //   process.exit(exitCode);
-  // });
-  app.registerProcessSignals();
+  app.registerProcessSignals(exitCode => {
+    process.exit(exitCode);
+  });
 
   // start the app!
   // you can pass custom configuration to the process as needed

--- a/templates/projectServer.ts.template
+++ b/templates/projectServer.ts.template
@@ -8,7 +8,9 @@ async function main() {
   const app = new Process();
 
   // handle unix signals and uncaught exceptions & rejections
-  app.registerProcessSignals();
+  app.registerProcessSignals(exitCode => {
+    process.exit(exitCode);
+  });
 
   // start the app!
   // you can pass custom configuration to the process as needed


### PR DESCRIPTION
* provide a callback to `app.registerProcessSignals` which will be called when the app is fully shut down.  This provides an explicit place to call `process.exit()`, which will in turn ensure that all sub-processes are exited too.
* on a `uncaughtRejection` or `uncaughtRejection`, try to gracefully shut down the server with `process.stop()`. 
  * Wait `process.env.ACTIONHERO_SHUTDOWN_TIMEOUT` (or 30 seconds) and then `process.exit()`
* only catch one `uncaughtRejection` or `uncaughtRejection`

The recommended `server.ts` is now:

```ts
import { Process } from "./index";

// load any custom code, configure the env, as needed

async function main() {
  // create a new actionhero process
  const app = new Process();

  // handle unix signals and uncaught exceptions & rejections
  app.registerProcessSignals(exitCode => {
    process.exit(exitCode);
  });

  // start the app!
  // you can pass custom configuration to the process as needed
  await app.start();
}

main();
```