### PR TITLE
Add VSCode debug task for jest

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,6 +22,21 @@
       "preLaunchTask": "tsc: build - tsconfig.json",
       "outFiles": ["${workspaceFolder}/dist/**/*.js"],
       "outputCapture": "std"
+    },
+
+    {
+      "name": "Debug Jest Tests",
+      "type": "node",
+      "request": "launch",
+      "runtimeArgs": [
+        "--inspect-brk",
+        "${workspaceRoot}/node_modules/.bin/jest",
+        "--runInBand",
+        "${workspaceRoot}/__tests__"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "port": 9229
     }
   ]
 }


### PR DESCRIPTION
We can use the integrated VSCode debugger to run Jest tests as well!  The normal breakpoints and debug console work as expected.

Downsides:
- If you are paused at a break point, that probably means your test will fail because it took too long (default 5 seconds)
- This VSCode task by default will run _every_ test in your project.  You will need to modify the `runtimeArgs` to pass in a single test file. 

<img width="1498" alt="Screen Shot 2020-04-22 at 6 27 19 PM" src="https://user-images.githubusercontent.com/303226/80049240-3291dd80-84c7-11ea-955b-b8d753aaeb13.png">