### PR TITLE
Implement ignorable route prefixes for static and regular-expression routes

### DIFF
--- a/src/initializers/routes.ts
+++ b/src/initializers/routes.ts
@@ -116,20 +116,32 @@ export class Routes extends Initializer {
 
         if (!pathPart) {
           return response;
-        } else if (matchPart[0] === ":" && matchPart.indexOf("(") < 0) {
-          variable = matchPart.replace(":", "");
-          response.params[variable] = pathPart;
-        } else if (matchPart[0] === ":" && matchPart.indexOf("(") >= 0) {
-          variable = matchPart.replace(":", "").split("(")[0];
-          regexp = matchPart.substring(
-            matchPart.indexOf("(") + 1,
-            matchPart.length - 1
-          );
-          const matches = pathPart.match(new RegExp(regexp, "g"));
-          if (matches) {
+        }
+
+        if (matchPart.indexOf(":") >= 0) {
+          const trimmedMatchParts = matchPart.split(":");
+          const trimmedMatchPart =
+            trimmedMatchParts[trimmedMatchParts.length - 1];
+          const replacement = trimmedMatchParts[trimmedMatchParts.length - 2];
+          if (replacement) {
+            pathPart = pathPart.replace(replacement, "");
+          }
+
+          if (trimmedMatchPart.indexOf("(") < 0) {
+            variable = trimmedMatchPart;
             response.params[variable] = pathPart;
           } else {
-            return response;
+            variable = trimmedMatchPart.replace(":", "").split("(")[0];
+            regexp = trimmedMatchPart.substring(
+              trimmedMatchPart.indexOf("(") + 1,
+              trimmedMatchPart.length - 1
+            );
+            const matches = pathPart.match(new RegExp(regexp, "g"));
+            if (matches) {
+              response.params[variable] = pathPart;
+            } else {
+              return response;
+            }
           }
         } else {
           if (


### PR DESCRIPTION
This PR allows `routes` to be matched against an arbitrary prefix before the ':' variable demarkation.  This allows things like `api/v2/myAction` when your action's version is `2`.  

```ts
// in routes.ts

export const DEFAULT = {
  routes: (config) => {
    return {
      get: [{ path: "/v:apiVersion/myAction", action: "myAction" }],
    };
  },
};

```

Prior to this PR, the "v" before the ":" would always fail to match a request URL.