### PR TITLE
Global api object via `global`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,9 +102,9 @@ jobs:
       - image: selenium/standalone-chrome:latest
     <<: *shared-test-steps
 
-  test-node-v13:
+  test-node-v14:
     docker:
-      - image: circleci/node:13
+      - image: circleci/node:14
       - image: redis:4
       - image: selenium/standalone-chrome:latest
     <<: *shared-test-steps
@@ -164,7 +164,7 @@ workflows:
           requires:
             - linter
 
-      - test-node-v13:
+      - test-node-v14:
           filters:
             <<: *ignored-branches
           requires:
@@ -177,7 +177,7 @@ workflows:
             - test-node-v8
             - test-node-v10
             - test-node-v12
-            - test-node-v13
+            - test-node-v14
 
       - deploy-docs-website:
           filters:

--- a/__tests__/servers/web/routes/routes.ts
+++ b/__tests__/servers/web/routes/routes.ts
@@ -397,7 +397,6 @@ describe("Server: Web", () => {
         const body = await request
           .get(url + "/api/a/complex/theKey/__path-stuff")
           .then(toJson);
-        console.log(body);
         expect(body.requesterInformation.receivedParams.action).toEqual(
           "mimeTestAction"
         );

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,4 +31,8 @@ export { id } from "./classes/process/id";
 
 // API object to hold connections, actions, tasks, initializers, and servers
 import { Api } from "./classes/api";
-export const api = new Api();
+
+if (!globalThis.api) {
+  globalThis.api = new Api();
+}
+export const api = globalThis.api;

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,12 @@ export { id } from "./classes/process/id";
 // API object to hold connections, actions, tasks, initializers, and servers
 import { Api } from "./classes/api";
 
+// backwards-compatibility for older versions of node.js
+if (!globalThis) {
+  // @ts-ignore
+  globalThis = global;
+}
+
 if (!globalThis.api) {
   globalThis.api = new Api();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,12 +33,12 @@ export { id } from "./classes/process/id";
 import { Api } from "./classes/api";
 
 // backwards-compatibility for older versions of node.js
-if (!globalThis) {
-  // @ts-ignore
-  globalThis = global;
-}
+// we can't use globalThis for node v8, v10
 
-if (!globalThis.api) {
-  globalThis.api = new Api();
+// @ts-ignore
+if (!global.api) {
+  // @ts-ignore
+  global.api = new Api();
 }
-export const api = globalThis.api;
+// @ts-ignore
+export const api = global.api;


### PR DESCRIPTION
This PR enforces the "globalness" of the `api` object within Actionhero projects.  It was previously possible to have 2 different instances of the `api` object with working with plugins that had 2 different Actionhero paths (ie, they were both importing Actionhero from their local node_modules).  This led to lots of problems with un-initialized initializers and missing parts of the api namespace.

Normally, using global objects is frowned upon... but we really do want to enforce a process-wide single instance.  

It is still recommenced to access the `api` object via `import {api} from 'actionhero'` and not use the global object.

---

There's no good way to pollyfil `globalThis` for some of the older node versions we support, so we are using `global`.