### PR TITLE
always rely on headers["x-forwarded-proto"]  if present to detect request protocal

### DIFF
--- a/__tests__/servers/web/allowedRequestHosts.ts
+++ b/__tests__/servers/web/allowedRequestHosts.ts
@@ -60,6 +60,22 @@ describe("Server: Web", () => {
       }
     });
 
+    test("will redirect clients if they do not request the proper protocol", async () => {
+      try {
+        await request.get({
+          followRedirect: false,
+          url: url + "/api/randomNumber",
+          headers: { Host: "www.site.com" },
+        });
+        throw new Error("should not get here");
+      } catch (error) {
+        expect(error.statusCode).toEqual(302);
+        expect(error.response.body).toMatch(
+          /You are being redirected to https:\/\/www.site.com\/api\/randomNumber/
+        );
+      }
+    });
+
     test("will allow API access from the proper hosts", async () => {
       const response = await request.get({
         followRedirect: false,

--- a/src/servers/web.ts
+++ b/src/servers/web.ts
@@ -400,19 +400,16 @@ export class WebServer extends Server {
       }
     }
 
+    // check if this request (http://other-host.com) is in allowedRequestHosts ([https://host.com])
     if (
       this.config.allowedRequestHosts &&
       this.config.allowedRequestHosts.length > 0
     ) {
-      let guess = "http://";
-      if (this.config.secure) {
-        guess = "https://";
-      }
-      const fullRequestHost =
-        (req.headers["x-forwarded-proto"]
-          ? req.headers["x-forwarded-proto"] + "://"
-          : guess) + req.headers.host;
-      if (this.config.allowedRequestHosts.indexOf(fullRequestHost) < 0) {
+      const requestHost = req.headers["x-forwarded-proto"]
+        ? req.headers["x-forwarded-proto"] + "://" + req.headers.host
+        : (this.config.secure ? "https://" : "http://") + req.headers.host;
+
+      if (!this.config.allowedRequestHosts.includes(requestHost)) {
         const newHost = this.config.allowedRequestHosts[0];
         res.statusCode = 302;
         res.setHeader("Location", newHost + req.url);


### PR DESCRIPTION
closes https://github.com/actionhero/actionhero/issues/1480