### PR TITLE
Add action response to logger and user can disable and filter private…

### DIFF
--- a/src/classes/actionProcessor.ts
+++ b/src/classes/actionProcessor.ts
@@ -125,10 +125,8 @@ export class ActionProcessor {
 
     let filteredResponse;
     if (config.general.enableResponseLogging) {
-      log(`logAction this.response:${JSON.stringify(this.response)}`);
       filteredResponse = utils.filterResponseForLogging(this.response);
       logLine.response = JSON.stringify(filteredResponse);
-      log(`logAction logLine.response:${logLine.response}`);
     }
 
     if (error) {

--- a/src/classes/actionProcessor.ts
+++ b/src/classes/actionProcessor.ts
@@ -114,14 +114,22 @@ export class ActionProcessor {
     }
 
     const filteredParams = utils.filterObjectForLogging(this.params);
-
     const logLine = {
       to: this.connection.remoteIP,
       action: this.action,
       params: JSON.stringify(filteredParams),
       duration: this.duration,
       error: "",
+      response: undefined,
     };
+
+    let filteredResponse;
+    if (config.general.enableResponseLogging) {
+      log(`logAction this.response:${JSON.stringify(this.response)}`);
+      filteredResponse = utils.filterResponseForLogging(this.response);
+      logLine.response = JSON.stringify(filteredResponse);
+      log(`logAction logLine.response:${logLine.response}`);
+    }
 
     if (error) {
       if (error instanceof Error) {

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -22,7 +22,7 @@ export const DEFAULT = {
       // disables the whitelisting of client params
       disableParamScrubbing: false,
       // enable action response to logger
-      enableResponseLogging: true,
+      enableResponseLogging: false,
       // params you would like hidden from any logs
       filteredParams: [],
       // responses you would like hidden from any logs

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -21,8 +21,12 @@ export const DEFAULT = {
       enforceConnectionProperties: true,
       // disables the whitelisting of client params
       disableParamScrubbing: false,
+      // enable action response to logger
+      enableResponseLogging: true,
       // params you would like hidden from any logs
       filteredParams: [],
+      // responses you would like hidden from any logs
+      filteredResponse: [],
       // values that signify missing params
       missingParamChecks: [null, "", undefined],
       // The default filetype to server when a user requests a directory

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -5,6 +5,7 @@ import { collapseObjectToArray } from "./utils/collapseObjectToArray";
 import { ensureNoTsHeaderFiles } from "./utils/ensureNoTsHeaderFiles";
 import { eventLoopDelay } from "./utils/eventLoopDelay";
 import { filterObjectForLogging } from "./utils/filterObjectForLogging";
+import { filterResponseForLogging } from "./utils/filterResponseForLogging";
 import { getExternalIPAddress } from "./utils/getExternalIPAddress";
 import { hashMerge } from "./utils/hashMerge";
 import { isPlainObject } from "./utils/isPlainObject";
@@ -36,6 +37,7 @@ export const utils = {
   ensureNoTsHeaderFiles,
   eventLoopDelay,
   filterObjectForLogging,
+  filterResponseForLogging,
   getExternalIPAddress,
   hashMerge,
   isPlainObject,

--- a/src/modules/utils/filterResponseForLogging.ts
+++ b/src/modules/utils/filterResponseForLogging.ts
@@ -1,0 +1,32 @@
+import { isPlainObject } from "./isPlainObject";
+import { config } from "../config";
+import * as dotProp from "dot-prop";
+
+/**
+ * Prepares acton response for logging.
+ * Hides any sensitive data as defined by `api.config.general.filteredResponse`
+ * Truncates long strings via `api.config.logger.maxLogStringLength`
+ */
+export function filterResponseForLogging(
+  response: object
+): { [key: string]: any } {
+  const filteredResponse = {};
+  for (const i in response) {
+    if (isPlainObject(response[i])) {
+      filteredResponse[i] = Object.assign({}, response[i]);
+    } else if (typeof response[i] === "string") {
+      filteredResponse[i] = response[i].substring(
+        0,
+        config.logger.maxLogStringLength
+      );
+    } else {
+      filteredResponse[i] = response[i];
+    }
+  }
+  config.general.filteredResponse.forEach((configParam) => {
+    if (dotProp.get(response, configParam) !== undefined) {
+      dotProp.set(filteredResponse, configParam, "[FILTERED]");
+    }
+  });
+  return filteredResponse;
+}


### PR DESCRIPTION
I add action response object to logger.
User can disable this by set enableResponseLogging = false in config/api.ts.
And when the response object contain private information, it can be filter by set filteredResponse to whatever you want.