### PR TITLE
Action and Task errors log on only one line

### DIFF
--- a/src/classes/actionProcessor.ts
+++ b/src/classes/actionProcessor.ts
@@ -130,8 +130,10 @@ export class ActionProcessor {
     }
 
     if (error) {
+      logLevel = "error";
       if (error instanceof Error) {
         logLine.error = error.toString();
+        logLine["stacktrace"] = error.stack;
       } else {
         try {
           logLine.error = JSON.stringify(error);
@@ -142,9 +144,6 @@ export class ActionProcessor {
     }
 
     log(`[ action @ ${this.connection.type} ]`, logLevel, logLine);
-    if (error?.stack) {
-      error.stack.split(EOL).map((l) => log(` ! ${l}`, "error"));
-    }
   }
 
   private async preProcessAction() {

--- a/src/classes/actionProcessor.ts
+++ b/src/classes/actionProcessor.ts
@@ -133,7 +133,16 @@ export class ActionProcessor {
       logLevel = "error";
       if (error instanceof Error) {
         logLine.error = error.toString();
-        logLine["stacktrace"] = error.stack;
+        Object.getOwnPropertyNames(error)
+          .filter((prop) => prop !== "message")
+          .sort((a, b) => {
+            if (a === "stack") return -1;
+            if (b === "stack") return -1;
+            return 1;
+          })
+          .map((prop) => {
+            logLine[prop] = error[prop];
+          });
       } else {
         try {
           logLine.error = JSON.stringify(error);

--- a/src/classes/actionProcessor.ts
+++ b/src/classes/actionProcessor.ts
@@ -135,14 +135,8 @@ export class ActionProcessor {
         logLine.error = error.toString();
         Object.getOwnPropertyNames(error)
           .filter((prop) => prop !== "message")
-          .sort((a, b) => {
-            if (a === "stack") return -1;
-            if (b === "stack") return -1;
-            return 1;
-          })
-          .map((prop) => {
-            logLine[prop] = error[prop];
-          });
+          .sort((a, b) => (a === "stack" || b === "stack" ? -1 : 1))
+          .forEach((prop) => (logLine[prop] = error[prop]));
       } else {
         try {
           logLine.error = JSON.stringify(error);

--- a/src/config/errors.ts
+++ b/src/config/errors.ts
@@ -10,25 +10,22 @@ export const DEFAULT = {
       serializers: {
         servers: {
           web: (error) => {
-            if (error.message) {
-              return String(error.message);
-            } else {
-              return error;
-            }
+            return {
+              message: error.message ? error.message : String(error),
+              code: error.code,
+            };
           },
           websocket: (error) => {
-            if (error.message) {
-              return String(error.message);
-            } else {
-              return error;
-            }
+            return {
+              message: error.message ? error.message : String(error),
+              code: error.code,
+            };
           },
           specHelper: (error) => {
-            if (error.message) {
-              return "Error: " + String(error.message);
-            } else {
-              return error;
-            }
+            return {
+              message: error.message ? error.message : String(error),
+              code: error.code,
+            };
           },
         },
       },

--- a/src/config/errors.ts
+++ b/src/config/errors.ts
@@ -10,22 +10,25 @@ export const DEFAULT = {
       serializers: {
         servers: {
           web: (error) => {
-            return {
-              message: error.message ? error.message : String(error),
-              code: error.code,
-            };
+            if (error.message) {
+              return String(error.message);
+            } else {
+              return error;
+            }
           },
           websocket: (error) => {
-            return {
-              message: error.message ? error.message : String(error),
-              code: error.code,
-            };
+            if (error.message) {
+              return String(error.message);
+            } else {
+              return error;
+            }
           },
           specHelper: (error) => {
-            return {
-              message: error.message ? error.message : String(error),
-              code: error.code,
-            };
+            if (error.message) {
+              return "Error: " + String(error.message);
+            } else {
+              return error;
+            }
           },
         },
       },

--- a/src/initializers/exceptions.ts
+++ b/src/initializers/exceptions.ts
@@ -5,7 +5,6 @@ export interface ExceptionHandlerAPI {
   reporters: Array<any>;
   report: Function;
   loader?: Function;
-  action?: Function;
   task?: Function;
 }
 
@@ -43,65 +42,29 @@ export class Exceptions extends Initializer {
     };
 
     const consoleReporter = (error, type, name, objects, severity) => {
-      const extraMessages = [];
+      let message = "";
+      const data = {};
 
       if (type === "loader") {
-        extraMessages.push("! Failed to load " + objects.fullFilePath);
-      } else if (type === "action") {
-        extraMessages.push("! uncaught error from action: " + name);
-        extraMessages.push("! connection details:");
-        const relevantDetails = this.relevantDetails();
-        for (const i in relevantDetails) {
-          const relevantDetail = relevantDetails[i];
-          if (
-            objects.connection[relevantDetail] !== null &&
-            objects.connection[relevantDetail] !== undefined &&
-            typeof objects.connection[relevantDetail] !== "function"
-          ) {
-            extraMessages.push(
-              "!     " +
-                relevantDetail +
-                ": " +
-                JSON.stringify(objects.connection[relevantDetail])
-            );
-          }
-        }
+        message = `Failed to load ${objects.fullFilePath}`;
       } else if (type === "task") {
-        extraMessages.push(
-          "! error from task: " +
-            name +
-            " on queue " +
-            objects.queue +
-            " (worker #" +
-            objects.workerId +
-            ")"
-        );
-        try {
-          extraMessages.push(
-            "!     arguments: " + JSON.stringify(objects.task.args)
-          );
-        } catch (e) {}
+        message = `error from task`;
+        data["name"] = name;
+        data["queue"] = objects.queue;
+        data["worker"] = objects.workerId;
+        data["arguments"] = objects?.task?.args
+          ? JSON.stringify(objects.task.args[0])
+          : undefined;
       } else {
-        extraMessages.push("! Error: " + error.message);
-        extraMessages.push("!     Type: " + type);
-        extraMessages.push("!     Name: " + name);
-        extraMessages.push("!     Data: " + JSON.stringify(objects));
+        message = `Error: ${error?.message || error.toString()}`;
+        data["type"] = type;
+        data["name"] = name;
+        data["data"] = objects;
       }
 
-      for (const m in extraMessages) {
-        log(extraMessages[m], severity);
-      }
-      let lines;
-      try {
-        lines = error.stack.split(os.EOL);
-      } catch (e) {
-        lines = new Error(error).stack.split(os.EOL);
-      }
-      for (const l in lines) {
-        const line = lines[l];
-        log("! " + line, severity);
-      }
-      log("*", severity);
+      data["stacktrace"] = error?.stack;
+
+      log(message, severity, data);
     };
 
     api.exceptionHandlers.reporters.push(consoleReporter);
@@ -115,27 +78,6 @@ export class Exceptions extends Initializer {
         { fullFilePath: fullFilePath },
         "alert"
       );
-    };
-
-    api.exceptionHandlers.action = (error, data, next) => {
-      let simpleName;
-      try {
-        simpleName = data.action;
-      } catch (e) {
-        simpleName = error.message;
-      }
-      const name = "action:" + simpleName;
-      api.exceptionHandlers.report(
-        error,
-        "action",
-        name,
-        { connection: data.connection },
-        "error"
-      );
-      data.connection.response = {}; // no partial responses
-      if (typeof next === "function") {
-        next();
-      }
     };
 
     api.exceptionHandlers.task = (error, queue, task, workerId) => {

--- a/src/initializers/exceptions.ts
+++ b/src/initializers/exceptions.ts
@@ -57,6 +57,10 @@ export class Exceptions extends Initializer {
           : undefined;
       } else {
         message = `Error: ${error?.message || error.toString()}`;
+        Object.getOwnPropertyNames(error)
+          .filter((prop) => prop !== "message")
+          .sort((a, b) => (a === "stack" || b === "stack" ? -1 : 1))
+          .forEach((prop) => (data[prop] = error[prop]));
         data["type"] = type;
         data["name"] = name;
         data["data"] = objects;


### PR DESCRIPTION
closes https://github.com/actionhero/actionhero/issues/1504

Actions and tasks now log to one line in the file and other transports.  The stack trace contains `\n` so it still is legible pretty in the console. 


**Action**
```bash
# Console
2020-06-25T00:48:24.045Z - error: [ action @ web ] to=127.0.0.1 action=broken params={"action":"broken","apiVersion":1} duration=1 error=TypeError: Cannot read property 'missing' of undefined stacktrace=TypeError: Cannot read property 'missing' of undefined
    at ValidationTest.run (/Users/evan/workspace/actionhero/actionhero/src/actions/broken.ts:14:27)
    at ActionProcessor.runAction (/Users/evan/workspace/actionhero/actionhero/src/classes/actionProcessor.ts:378:35)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)

# File
{"to":"127.0.0.1","action":"broken","params":"{\"action\":\"broken\",\"apiVersion\":1}","duration":1,"error":"TypeError: Cannot read property 'missing' of undefined","stacktrace":"TypeError: Cannot read property 'missing' of undefined\n    at ValidationTest.run (/Users/evan/workspace/actionhero/actionhero/src/actions/broken.ts:14:27)\n    at ActionProcessor.runAction (/Users/evan/workspace/actionhero/actionhero/src/classes/actionProcessor.ts:378:35)\n    at processTicksAndRejections (internal/process/task_queues.js:97:5)\n    at WebServer.processAction (/Users/evan/workspace/actionhero/actionhero/src/classes/server.ts:229:18)","level":"error","message":"[ action @ web ]","timestamp":"2020-06-25T00:48:24.045Z"}

```

**Task**

```bash
# Console
2020-06-25T00:38:03.840Z - error: error from task: task:busted on queue default (worker #1) arguments=[object Object] stacktrace=Error: NOPE
    at MyTask.run (/Users/evan/workspace/actionhero/actionhero/src/tasks/busted.ts:14:11)
    at Worker.perform (/Users/evan/workspace/actionhero/actionhero/src/initializers/tasks.ts:123:39)
    at Worker.perform (/Users/evan/workspace/actionhero/actionhero/node_modules/node-resque/dist/core/worker.js:165:41)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)

# File
{"name":"task:busted","queue":"default","worker":1,"arguments":"{}","stacktrace":"Error: NOPE\n    at MyTask.run (/Users/evan/workspace/actionhero/actionhero/src/tasks/busted.ts:14:11)\n    at Worker.perform (/Users/evan/workspace/actionhero/actionhero/src/initializers/tasks.ts:123:39)\n    at Worker.perform (/Users/evan/workspace/actionhero/actionhero/node_modules/node-resque/dist/core/worker.js:165:41)\n    at processTicksAndRejections (internal/process/task_queues.js:97:5)","level":"error","message":"error from task","timestamp":"2020-06-25T00:48:28.478Z"}

```

This PR also adds support for rendering custom Error properties, ie:
```ts
import { api, Action } from "./../index";

class AuthenticationError extends Error {
  code: string;

  constructor(message, code = "AUTHENTICATION_ERROR") {
    super(message);
    this.code = code;
  }
}

export class ValidationTest extends Action {
  constructor() {
    super();
    this.name = "broken";
    this.description = "I am broken";
    this.inputs = {};
    this.outputExample = {};
  }

  async run({ params, response }) {
    throw new AuthenticationError(`broken`);
  }
}

```


Co Authored with @gcoonrod 