### PR TITLE
`config.tasks.queues` can be a static array or an async function that returns list of queues

### DIFF
--- a/__tests__/core/tasks/customQueueFunction.ts
+++ b/__tests__/core/tasks/customQueueFunction.ts
@@ -1,0 +1,67 @@
+import { api, Process, utils, config } from "./../../../src/index";
+
+const actionhero = new Process();
+let taskOutput = [];
+const queue = "testQueue";
+
+jest.mock("./../../../src/config/tasks.ts", () => ({
+  __esModule: true,
+  test: {
+    tasks: () => {
+      return {
+        _toExpand: false,
+
+        scheduler: false,
+        queues: async () => {
+          await new Promise((resolve) => setTimeout(resolve, 100));
+          return ["queueA", "queueB"];
+        },
+        workerLogging: {},
+        schedulerLogging: {},
+        timeout: 100,
+        checkTimeout: 50,
+        minTaskProcessors: 1,
+        maxTaskProcessors: 1,
+        maxEventLoopDelay: 5,
+        stuckWorkerTimeout: 1000 * 60 * 60,
+        connectionOptions: {
+          tasks: {},
+        },
+      };
+    },
+  },
+}));
+
+describe("Core: Tasks", () => {
+  describe("custom queues function", () => {
+    beforeAll(async () => {
+      await actionhero.start();
+      api.resque.multiWorker.options.connection.redis.setMaxListeners(100);
+    });
+
+    afterAll(async () => {
+      config.tasks.queues = [];
+
+      api.resque.multiWorker.options.minTaskProcessors = 0;
+      api.resque.multiWorker.options.maxTaskProcessors = 0;
+
+      await actionhero.stop();
+    });
+
+    beforeEach(async () => {
+      taskOutput = [];
+      await api.resque.queue.connection.redis.flushdb();
+    });
+
+    test("normal tasks work", async () => {
+      api.resque.multiWorker.start();
+      await utils.sleep(2000);
+
+      expect(api.resque.multiWorker.workers[0].queues).toEqual([
+        "queueA",
+        "queueB",
+      ]);
+      await api.resque.multiWorker.stop();
+    });
+  });
+});

--- a/src/config/tasks.ts
+++ b/src/config/tasks.ts
@@ -1,10 +1,16 @@
 export const DEFAULT = {
   tasks: (config) => {
     return {
+      _toExpand: false,
+
       // Should this node run a scheduler to promote delayed tasks?
       scheduler: false,
+
       // what queues should the taskProcessors work?
       queues: ["*"],
+      // Or, rather than providing a static list of `queues`, you can define a method that returns the list of queues.
+      // queues: async () => { return ["queueA", "queueB"]; },
+
       // Logging levels of task workers
       workerLogging: {
         failure: "error", // task failure

--- a/src/initializers/resque.ts
+++ b/src/initializers/resque.ts
@@ -27,7 +27,7 @@ export class Resque extends Initializer {
     super();
     this.name = "resque";
     this.loadPriority = 600;
-    this.startPriority = 200;
+    this.startPriority = 950;
     this.stopPriority = 100;
   }
 
@@ -146,7 +146,9 @@ export class Resque extends Initializer {
         api.resque.multiWorker = new ActionheroMultiWorker(
           {
             connection: api.resque.connectionDetails,
-            queues: config.tasks.queues,
+            queues: Array.isArray(config.tasks.queues)
+              ? config.tasks.queues
+              : await config.tasks.queues(),
             timeout: config.tasks.timeout,
             checkTimeout: config.tasks.checkTimeout,
             minTaskProcessors: config.tasks.minTaskProcessors,


### PR DESCRIPTION
This PR allows `api.tasks.queues` to be either a static array or an async function that returns a list of queues.  This method will be called once when the server starts.  In this way, you can provide custom logic to build up your list of queues for this server.

```ts
// config/tasks.ts

export const DEFAULT = {
  tasks: (config) => {
    return {
      _toExpand: false,

      // Should this node run a scheduler to promote delayed tasks?
      scheduler: false,

      // what queues should the taskProcessors work?
      queues: ["*"],
      // Or, rather than providing a static list of `queues`, you can define a method that returns the list of queues.
      queues: async () => { return ["queueA", "queueB"]; },

// ...

```