### PR TITLE
feat: action validate inputs has reserved param

### DIFF
--- a/src/classes/action.ts
+++ b/src/classes/action.ts
@@ -94,5 +94,13 @@ export abstract class Action {
         `action \`${this.name}\` is a reserved verb for connections. choose a new name`
       );
     }
+
+    Object.keys(this.inputs).forEach((input) => {
+      if (api.params.globalSafeParams.indexOf(input) >= 0) {
+        throw new Error(
+          `action \`${this.name}\` input \`${input}\` is a reserved param. choose a new input`
+        );
+      }
+    });
   }
 }


### PR DESCRIPTION
issue:
My colleague meets the issue, he adds an "action" key in an action input...
but "action" is a keyword, apiVersion also.
can we have a checker to avoid it? even in build time or runtime.
[Example](https://github.com/allyusd/actionhero-action-inputs-using-reserved-params/blob/master/src/actions/usingReservedParams.ts)

problem:
I was tried to add `class/action.ts` validate using `api.params.globalSafeParams` of `initializers/params.ts`

But `action.validate` called by `initializers/action.ts` and its load priority is 410 and `params.ts` is 420.
So `api.parmas` is undefined when `action.validate` is call.
I was tried to change load priority, but I found `params.ts` need `api.actions` two... It's a deadlock, have any idea?
