### PR TITLE
Validate that Action inputs do not use reserved params

### DIFF
--- a/__tests__/core/api.ts
+++ b/__tests__/core/api.ts
@@ -181,6 +181,28 @@ describe("Core", () => {
           expect(error.toString()).toMatch(/name is required for this action/);
         }
       });
+
+      test("actions cannot use reserved params as inputs", () => {
+        class BadAction extends Action {
+          constructor() {
+            super();
+            this.name = "bad";
+            this.description = "bad";
+            this.outputExample = {};
+            this.inputs = {
+              apiVersion: { required: true },
+            };
+          }
+
+          async run() {}
+        }
+
+        const badAction = new BadAction();
+
+        expect(() => badAction.validate()).toThrow(
+          "input `apiVersion` in action `bad` is a reserved param"
+        );
+      });
     });
 
     describe("Action Params", () => {

--- a/src/classes/action.ts
+++ b/src/classes/action.ts
@@ -94,5 +94,13 @@ export abstract class Action {
         `action \`${this.name}\` is a reserved verb for connections. choose a new name`
       );
     }
+
+    Object.keys(this.inputs).forEach((input) => {
+      if (api.params.globalSafeParams.indexOf(input) >= 0) {
+        throw new Error(
+          `action \`${this.name}\` input \`${input}\` is a reserved param. choose a new input`
+        );
+      }
+    });
   }
 }

--- a/src/classes/action.ts
+++ b/src/classes/action.ts
@@ -98,7 +98,7 @@ export abstract class Action {
     Object.keys(this.inputs).forEach((input) => {
       if (api.params.globalSafeParams.indexOf(input) >= 0) {
         throw new Error(
-          `action \`${this.name}\` input \`${input}\` is a reserved param`
+          `input \`${input}\` in action \`${this.name}\` is a reserved param`
         );
       }
     });

--- a/src/classes/action.ts
+++ b/src/classes/action.ts
@@ -98,7 +98,7 @@ export abstract class Action {
     Object.keys(this.inputs).forEach((input) => {
       if (api.params.globalSafeParams.indexOf(input) >= 0) {
         throw new Error(
-          `action \`${this.name}\` input \`${input}\` is a reserved param. choose a new input`
+          `action \`${this.name}\` input \`${input}\` is a reserved param`
         );
       }
     });

--- a/src/initializers/actions.ts
+++ b/src/initializers/actions.ts
@@ -116,5 +116,8 @@ export class Actions extends Initializer {
           .forEach((f) => api.actions.loadFile(f));
       }
     }
+
+    // now that the actions are loaded, we can add all the inputs to api.params
+    api.params.buildPostVariables();
   }
 }

--- a/src/initializers/params.ts
+++ b/src/initializers/params.ts
@@ -13,7 +13,7 @@ export class Params extends Initializer {
   constructor() {
     super();
     this.name = "params";
-    this.loadPriority = 420;
+    this.loadPriority = 400;
   }
 
   async initialize() {
@@ -51,7 +51,5 @@ export class Params extends Initializer {
       api.params.postVariables = utils.arrayUnique(postVariables);
       return api.params.postVariables;
     };
-
-    api.params.buildPostVariables();
   }
 }


### PR DESCRIPTION
An expansion on https://github.com/actionhero/actionhero/pull/1520

This PR also moves calling `api.params.buildPostVariables()` to the action initializer so can load `api.params.globalSafeParams` earlier in the boot process.

---

Original Description:

issue:
My colleague meets the issue, he adds an "action" key in an action input...
but "action" is a keyword, apiVersion also.
can we have a checker to avoid it? even in build time or runtime.
[Example](https://github.com/allyusd/actionhero-action-inputs-using-reserved-params/blob/master/src/actions/usingReservedParams.ts)

problem:
I was tried to add `class/action.ts` validate using `api.params.globalSafeParams` of `initializers/params.ts`

But `action.validate` called by `initializers/action.ts` and its load priority is 410 and `params.ts` is 420.
So `api.parmas` is undefined when `action.validate` is call.
I was tried to change load priority, but I found `params.ts` need `api.actions` two... It's a deadlock, have any idea?
