### PR TITLE
Do not rely on serverInformation for index stats

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -95,13 +95,9 @@
 
     <script type="text/javascript">
       var populateStatus = function (data) {
-        if (data.serverInformation) {
-          document.getElementById("serverVersion").innerHTML =
-            data.serverInformation.apiVersion;
-          document.getElementById("serverName").innerHTML =
-            data.serverInformation.serverName;
-          document.getElementById("serverId").innerHTML = data.id;
-        }
+        document.getElementById("serverVersion").innerHTML = data.version;
+        document.getElementById("serverName").innerHTML = data.name;
+        document.getElementById("serverId").innerHTML = data.id;
         document.getElementById("actionheroVersion").innerHTML =
           data.actionheroVersion;
         document.getElementById("uptime").innerHTML = Math.round(

--- a/src/actions/swagger.ts
+++ b/src/actions/swagger.ts
@@ -16,7 +16,7 @@ const responses = {
     description: "Invalid input",
   },
   404: {
-    description: "Not Fount",
+    description: "Not Found",
   },
   422: {
     description: "Missing or invalid params",


### PR DESCRIPTION
In environments other than `development`, we don't return `serverInformation` with API calls by default.   This PR changes the behavior of `index.html` to read the status values from the status action's response directly.  