### PR TITLE
Do not throw error when enqueueAllRecurrentTasks encounters the task already enqueued

### DIFF
--- a/__tests__/core/tasks/tasks.ts
+++ b/__tests__/core/tasks/tasks.ts
@@ -261,6 +261,13 @@ describe("Core: Tasks", () => {
     expect(length).toEqual(1);
   });
 
+  test("re-enquing a recurring task will not throw", async () => {
+    await task.enqueueAllRecurrentTasks();
+    await task.enqueueAllRecurrentTasks(); // does not throw
+    const length = await api.resque.queue.length(queue);
+    expect(length).toEqual(1);
+  });
+
   test("re-enqueuing a periodic task should not enqueue it again", async () => {
     const tryOne = await task.enqueue("periodicTask", null);
     const tryTwo = await task.enqueue("periodicTask", null);


### PR DESCRIPTION
When calling `task.enqueueAllRecurrentTasks()` (which happens automatically at startup), there may be a race condition in which 2 instances of the recurring task are attempted to be enqueued at the same time.  Before this PR, one of the tasks would throw an error, and possibly end up in the resque error queue.   In reality, we only want one instance of each recurring task enqueued anyway, so we shouldn't throw... we now just log.