### PR TITLE
Brings back api.exceptionHandlers.action for logging action errors with third-party error reporters

### DIFF
--- a/src/classes/actionProcessor.ts
+++ b/src/classes/actionProcessor.ts
@@ -103,11 +103,11 @@ export class ActionProcessor {
     this.incrementPendingActions(-1);
     this.duration = new Date().getTime() - this.actionStartTime;
     this.working = false;
-    this.logAction(error);
+    this.logAndReportAction(error);
     return this;
   }
 
-  private logAction(error) {
+  private logAndReportAction(error) {
     let logLevel = "info";
     if (this.actionTemplate && this.actionTemplate.logLevel) {
       logLevel = this.actionTemplate.logLevel;
@@ -147,6 +147,7 @@ export class ActionProcessor {
     }
 
     log(`[ action @ ${this.connection.type} ]`, logLevel, logLine);
+    if (error) api.exceptionHandlers.action(error, logLine);
   }
 
   private async preProcessAction() {


### PR DESCRIPTION
Returns `api.exceptionHandlers.action` so that errors from actions can be passed to third-party error reporters.  IE:

```ts
api.exceptionHandlers.reporters.push((error: Error) => {
  Sentry.captureException(error);
});
```

The `actionProcessor` still handles logging the action.

Related to https://github.com/actionhero/ah-sentry-plugin