### PR TITLE
Help should be the default command when running the Actionhero CLI

### DIFF
--- a/src/bin/actionhero.ts
+++ b/src/bin/actionhero.ts
@@ -179,7 +179,7 @@ const projectRoot = determineProjectRoot();
 
   const commands = [];
   if (!optimist.argv._ || optimist.argv._.length === 0) {
-    commands.push("start");
+    commands.push("help");
   }
   optimist.argv._.forEach(function (arg: string) {
     commands.push(arg);


### PR DESCRIPTION
It was previously 'start', which has been removed