### PR TITLE
Do not 'start' the server in the CLI console

### DIFF
--- a/src/bin/methods/console.ts
+++ b/src/bin/methods/console.ts
@@ -1,5 +1,5 @@
 import * as REPL from "repl";
-import {  api, env, CLI } from "./../../index";
+import { api, env, CLI } from "./../../index";
 
 export class Console extends CLI {
   constructor() {

--- a/src/bin/methods/console.ts
+++ b/src/bin/methods/console.ts
@@ -1,5 +1,5 @@
 import * as REPL from "repl";
-import { config, api, env, utils, CLI } from "./../../index";
+import {  api, env, CLI } from "./../../index";
 
 export class Console extends CLI {
   constructor() {
@@ -10,18 +10,6 @@ export class Console extends CLI {
   }
 
   async run() {
-    for (const i in config.servers) {
-      config.servers[i].enabled = false;
-    }
-    config.general.developmentMode = false;
-    config.tasks.scheduler = false;
-    config.tasks.queues = [];
-    config.tasks.minTaskProcessors = 0;
-    config.tasks.maxTaskProcessors = 0;
-
-    await api.commands.start.call(api.process);
-    await utils.sleep(500);
-
     await new Promise((resolve, reject) => {
       const repl = REPL.start({
         prompt: "[ AH::" + env + " ] >> ",


### PR DESCRIPTION
When running `actionhero console` to get a CLI instance, we should not try to 'start' the server, only to initialize it.  Also, `config` is no longer mutable, so there's no reliable way to disable the servers if we did try to start the server.