### PR TITLE
Do not stop the shutdown timer on the second SIGINT/SIGTERM

### DIFF
--- a/src/classes/process.ts
+++ b/src/classes/process.ts
@@ -363,16 +363,20 @@ export class Process {
       log(`[ SIGNAL ] - SIGINT`, "notice");
       let timer = awaitHardStop();
       await this.stop();
-      clearTimeout(timer);
-      stopCallback(0);
+      if (!this.shuttingDown) {
+        clearTimeout(timer);
+        stopCallback(0);
+      }
     });
 
     process.on("SIGTERM", async () => {
       log(`[ SIGNAL ] - SIGTERM`, "notice");
       let timer = awaitHardStop();
       await this.stop();
-      clearTimeout(timer);
-      stopCallback(0);
+      if (!this.shuttingDown) {
+        clearTimeout(timer);
+        stopCallback(0);
+      }
     });
 
     process.on("SIGUSR2", async () => {


### PR DESCRIPTION
Prevents a bug in which sending two stop signals to the Actionhero process (ie hitting `ctrl-c` rapidly) would short-circuit the work of the first stop signal. 