### PR TITLE
Do not try to re-enqueue a recurring task if another instance is already running

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5790,11 +5790,11 @@
       }
     },
     "node-resque": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/node-resque/-/node-resque-7.0.6.tgz",
-      "integrity": "sha512-dij29AQxbVwzy+1dwhBHQAJH9x4Ax2jufE3lqrcRi/erzscEy7BCk10OQal+r9Rdjbj7XMLTjDTrS8aHlxYm4g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-resque/-/node-resque-7.1.0.tgz",
+      "integrity": "sha512-M9RbyKhj3upJhOPZlBhGj4rr19PO0wdr8x2EL0C3kksajbSRLeDL5Tlu5kIXcl0jPEmKIY0NNnvsA2sLl2iHiQ==",
       "requires": {
-        "ioredis": "^4.16.1"
+        "ioredis": "^4.17.3"
       }
     },
     "normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "ioredis": "^4.17.3",
     "is-running": "^2.1.0",
     "mime": "^2.4.6",
-    "node-resque": "^7.0.6",
+    "node-resque": "^7.1.0",
     "optimist": "^0.6.1",
     "primus": "^7.3.5",
     "qs": "^6.9.4",

--- a/src/initializers/tasks.ts
+++ b/src/initializers/tasks.ts
@@ -69,6 +69,7 @@ export class Tasks extends Initializer {
       if (task.frequency > 0) {
         if (plugins.indexOf("JobLock") < 0) {
           plugins.push("JobLock");
+          pluginOptions.JobLock = { reEnqueue: false };
         }
         if (plugins.indexOf("QueueLock") < 0) {
           plugins.push("QueueLock");


### PR DESCRIPTION
While rare, it is possible to end up with more than one instance of a recurring task enqueued in your Actionhero Cluster at the same time.  The most common way to end up in this state is:
1. A recurring task fails and is placed in the error queue.
2. The server reboots (or another Actionhero server joins the cluster) and re-adds an instance of the task that failed.
3. The failed task instance is retried.

In these cases, You'll likely end up with an error on one of those tasks that looks like `Job already enqueued at this time with same arguments`.  This comes from Node Resque's Job Lock plugin which we are using to ensure that no more than one instance of a recurring task can be running at a time.  That, along with the `queueLock` and `delayedQueueLock` plugins eventually sort out that there should only be one instance of the Task.  However, this error is noisy and we don't want to see it.  

This PR uses the new `JobLock` plugin options `pluginOptions: { JobLock: { reEnqueue: false } }` to just ignore the duplicate task and not try to re-enqueue it.

Requires https://github.com/actionhero/node-resque/pull/449 and https://github.com/actionhero/node-resque/releases/tag/v7.1.0