### PR TITLE
Export the winston loggers as "loggers" from Actionhero

### DIFF
--- a/__tests__/core/log.ts
+++ b/__tests__/core/log.ts
@@ -1,0 +1,23 @@
+import { log, loggers, Process } from "./../../src/index";
+
+const actionhero = new Process();
+
+describe("Core", () => {
+  describe("log", () => {
+    beforeAll(async () => {
+      await actionhero.start();
+    });
+
+    afterAll(async () => {
+      await actionhero.stop();
+    });
+
+    test("the log method should work", () => {
+      log("hello");
+    });
+
+    test("the winston loggers are available via api.loggers", () => {
+      expect(loggers.length).toBe(2);
+    });
+  });
+});

--- a/__tests__/core/log.ts
+++ b/__tests__/core/log.ts
@@ -16,7 +16,7 @@ describe("Core", () => {
       log("hello");
     });
 
-    test("the winston loggers are available via api.loggers", () => {
+    test("the winston loggers are available via the export loggers", () => {
       expect(loggers.length).toBe(2);
     });
   });

--- a/src/classes/actionProcessor.ts
+++ b/src/classes/actionProcessor.ts
@@ -4,7 +4,6 @@ import { config } from "./../modules/config";
 import { log } from "../modules/log";
 import { utils } from "../modules/utils";
 import * as dotProp from "dot-prop";
-import { EOL } from "os";
 import { api } from "../index";
 
 export class ActionProcessor {

--- a/src/classes/process.ts
+++ b/src/classes/process.ts
@@ -1,7 +1,6 @@
 import * as path from "path";
 import * as glob from "glob";
 import * as fs from "fs";
-import { Api } from "./api";
 import { buildConfig, ConfigInterface } from "./../modules/config";
 import { log } from "../modules/log";
 import { Initializer } from "./initializer";

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -1,12 +1,20 @@
 import * as winston from "winston";
 
-// learn more about winston v3 loggers @
-// - https://github.com/winstonjs/winston
-// - https://github.com/winstonjs/winston/blob/master/docs/transports.md
+/*
+The loggers defined here will eventually be available via `import { loggers } from "actionhero"`
+
+learn more about winston v3 loggers @
+ - https://github.com/winstonjs/winston
+ - https://github.com/winstonjs/winston/blob/master/docs/transports.md
+*/
+
+type ActionheroConfigLoggerBuilderArray = Array<
+  (config: any) => winston.Logger
+>;
 
 export const DEFAULT = {
   logger: (config) => {
-    const loggers = [];
+    const loggers: ActionheroConfigLoggerBuilderArray = [];
     loggers.push(buildConsoleLogger());
     config.general.paths.log.forEach((p) => {
       loggers.push(buildFileLogger(p));
@@ -14,25 +22,20 @@ export const DEFAULT = {
 
     return {
       loggers,
-
-      // the maximum length of param to log (we will truncate)
-      maxLogStringLength: 100,
+      maxLogStringLength: 100, // the maximum length of param to log (we will truncate)
     };
   },
 };
 
 export const test = {
   logger: (config) => {
-    const loggers = [];
-
+    const loggers: ActionheroConfigLoggerBuilderArray = [];
     loggers.push(buildConsoleLogger("crit"));
     config.general.paths.log.forEach((p) => {
       loggers.push(buildFileLogger(p, "debug", 1));
     });
 
-    return {
-      loggers,
-    };
+    return { loggers };
   },
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export { ActionProcessor } from "./classes/actionProcessor";
 // export modules (lower case)
 export { utils } from "./modules/utils";
 export { config } from "./modules/config";
-export { log } from "./modules/log";
+export { log, loggers } from "./modules/log";
 export { action } from "./modules/action";
 export { task } from "./modules/task";
 export { cache } from "./modules/cache";

--- a/src/modules/log.ts
+++ b/src/modules/log.ts
@@ -22,12 +22,14 @@ loggers = config.logger.loggers.map((loggerBuilder: Function) => {
 
 /**
  * Log a message, with optional metadata.  The message can be logged to a number of locations (stdio, files, etc) as configured via config/logger.js
- * The default log levels are: `7=debug` `6=info` `5=notice` `4=warning` `3=error` `2=crit` `1=alert` `0=emerg`
- * Learn more at https://github.com/winstonjs/winston
  *
- * the most basic use.  Will assume 'info' as the severity: `log('hello')`
- * custom severity: `log('OH NO!', 'warning')`
- * custom severity with a metadata object: `log('OH NO, something went wrong', 'warning', { error: new Error('things are busted') })`
+ * The most basic use.  Will assume 'info' as the severity: `log('hello')`
+ * Custom severity: `log('OH NO!', 'warning')`
+ * Custom severity with a metadata object: `log('OH NO, something went wrong', 'warning', { error: new Error('things are busted') })`
+ *
+ * The default log levels are: `emerg: 0, alert: 1, crit: 2,  error: 3,  warning: 4,  notice: 5, info: 6, debug: 7`.
+ * Logging levels in winston conform to the severity ordering specified by RFC5424: severity of all levels is assumed to be numerically ascending from most important to least important.
+ * Learn more at https://github.com/winstonjs/winston
  */
 export function log(message: string, severity: string = "info", data?: any) {
   loggers.map((logger) => {

--- a/src/modules/log.ts
+++ b/src/modules/log.ts
@@ -2,7 +2,8 @@ import * as winston from "winston";
 import { config } from "./config";
 import { utils } from "./utils";
 
-export let loggers = [];
+// exported as `import { loggers } from "actionhero"`
+export let loggers: winston.Logger[] = [];
 
 config.general.paths.log.forEach((p: string) => {
   try {


### PR DESCRIPTION
You can now `import {loggers} from 'actionhero'` to access the winston loggers you created in `config/loggers`.