### PR TITLE
Add automaticRoutes, Remove query and simple routing

### DIFF
--- a/__tests__/actions/swagger.ts
+++ b/__tests__/actions/swagger.ts
@@ -5,6 +5,7 @@ const actionhero = new Process();
 describe("Action", () => {
   describe("swagger", () => {
     beforeAll(async () => {
+      process.env.AUTOMATIC_ROUTES = "get";
       await actionhero.start();
     });
 

--- a/__tests__/core/config.ts
+++ b/__tests__/core/config.ts
@@ -69,6 +69,7 @@ describe("Core: config folders", () => {
   test("routes should be rebuilt and contain both paths", async () => {
     expect(config.routes).toEqual({
       get: [
+        { path: "/status", action: "status" },
         { path: "/api-status", action: "status" },
         { path: "/random-number", action: "randomNumber" },
       ],

--- a/__tests__/core/config.ts
+++ b/__tests__/core/config.ts
@@ -70,6 +70,8 @@ describe("Core: config folders", () => {
     expect(config.routes).toEqual({
       get: [
         { path: "/status", action: "status" },
+        { path: "/swagger", action: "swagger" },
+        { path: "/createChatRoom", action: "createChatRoom" },
         { path: "/api-status", action: "status" },
         { path: "/random-number", action: "randomNumber" },
       ],

--- a/__tests__/core/staticFile/compression.ts
+++ b/__tests__/core/staticFile/compression.ts
@@ -18,8 +18,6 @@ jest.mock("./../../../src/config/servers/web.ts", () => ({
           rootEndpointType: "file",
           port: 18080 + parseInt(process.env.JEST_WORKER_ID || "0"),
           matchExtensionMime: true,
-          simpleRouting: true,
-          queryRouting: true,
           metadataOptions: {
             serverInformation: true,
             requesterInformation: false,

--- a/__tests__/integration/browser.ts
+++ b/__tests__/integration/browser.ts
@@ -23,7 +23,6 @@ const ensureNoErrors = async () => {
 
 describe("browser integration tests", () => {
   beforeAll(async () => {
-    process.env.AUTOMATIC_ROUTES = "get";
     await actionhero.start();
     await api.redis.clients.client.flushdb();
     url = `http://${host}:${config.servers.web.port}`;
@@ -72,13 +71,9 @@ describe("browser integration tests", () => {
       const elements = await browser.findElements(by.tagName("h4"));
       const actionNames = await Promise.all(elements.map((e) => e.getText()));
       expect(actionNames.sort()).toEqual([
-        "cacheTest",
         "createChatRoom",
-        "randomNumber",
-        "sleepTest",
         "status",
         "swagger",
-        "validationTest",
       ]);
     });
   });

--- a/__tests__/integration/browser.ts
+++ b/__tests__/integration/browser.ts
@@ -23,6 +23,7 @@ const ensureNoErrors = async () => {
 
 describe("browser integration tests", () => {
   beforeAll(async () => {
+    process.env.AUTOMATIC_ROUTES = "get";
     await actionhero.start();
     await api.redis.clients.client.flushdb();
     url = `http://${host}:${config.servers.web.port}`;

--- a/__tests__/integration/sendBuffer.ts
+++ b/__tests__/integration/sendBuffer.ts
@@ -7,6 +7,7 @@ let url;
 
 describe("Server: sendBuffer", () => {
   beforeAll(async () => {
+    process.env.AUTOMATIC_ROUTES = "get";
     await actionhero.start();
     url = "http://localhost:" + config.servers.web.port;
   });

--- a/__tests__/integration/sharedFingerprint.ts
+++ b/__tests__/integration/sharedFingerprint.ts
@@ -31,6 +31,7 @@ const connectClient = async (query = ""): Promise<any> => {
 
 describe("Integration: Web Server + Websocket Socket shared fingerprint", () => {
   beforeAll(async () => {
+    process.env.AUTOMATIC_ROUTES = "get";
     await actionhero.start();
     await api.redis.clients.client.flushdb();
     url = "http://localhost:" + config.servers.web.port;

--- a/__tests__/servers/web/allowedRequestHosts.ts
+++ b/__tests__/servers/web/allowedRequestHosts.ts
@@ -18,8 +18,6 @@ jest.mock("./../../../src/config/servers/web.ts", () => ({
           rootEndpointType: "file",
           port: 18080 + parseInt(process.env.JEST_WORKER_ID || "0"),
           matchExtensionMime: true,
-          simpleRouting: true,
-          queryRouting: true,
           metadataOptions: {
             serverInformation: true,
             requesterInformation: false,

--- a/__tests__/servers/web/allowedRequestHosts.ts
+++ b/__tests__/servers/web/allowedRequestHosts.ts
@@ -12,6 +12,7 @@ jest.mock("./../../../src/config/servers/web.ts", () => ({
         return {
           enabled: true,
           secure: false,
+          automaticRoutes: "get",
           allowedRequestHosts: ["https://www.site.com"],
           urlPathForActions: "api",
           urlPathForFiles: "public",

--- a/__tests__/servers/web/allowedRequestHosts.ts
+++ b/__tests__/servers/web/allowedRequestHosts.ts
@@ -12,7 +12,7 @@ jest.mock("./../../../src/config/servers/web.ts", () => ({
         return {
           enabled: true,
           secure: false,
-          automaticRoutes: "get",
+          automaticRoutes: ["get"],
           allowedRequestHosts: ["https://www.site.com"],
           urlPathForActions: "api",
           urlPathForFiles: "public",

--- a/__tests__/servers/web/jsonp.ts
+++ b/__tests__/servers/web/jsonp.ts
@@ -17,8 +17,6 @@ jest.mock("./../../../src/config/servers/web.ts", () => ({
           rootEndpointType: "file",
           port: 18080 + parseInt(process.env.JEST_WORKER_ID || "0"),
           matchExtensionMime: true,
-          simpleRouting: true,
-          queryRouting: true,
           metadataOptions: {
             serverInformation: true,
             requesterInformation: false,

--- a/__tests__/servers/web/jsonp.ts
+++ b/__tests__/servers/web/jsonp.ts
@@ -11,7 +11,7 @@ jest.mock("./../../../src/config/servers/web.ts", () => ({
       web: () => {
         return {
           enabled: true,
-          automaticRoutes: "get,post",
+          automaticRoutes: ["get", "post"],
           secure: false,
           urlPathForActions: "api",
           urlPathForFiles: "public",

--- a/__tests__/servers/web/jsonp.ts
+++ b/__tests__/servers/web/jsonp.ts
@@ -11,6 +11,7 @@ jest.mock("./../../../src/config/servers/web.ts", () => ({
       web: () => {
         return {
           enabled: true,
+          automaticRoutes: "get,post",
           secure: false,
           urlPathForActions: "api",
           urlPathForFiles: "public",

--- a/__tests__/servers/web/rawBody.ts
+++ b/__tests__/servers/web/rawBody.ts
@@ -19,8 +19,9 @@ jest.mock("./../../../src/config/servers/web.ts", () => ({
     servers: {
       web: () => {
         return {
-          saveRawBody: true,
           enabled: true,
+          saveRawBody: true,
+          automaticRoutes: "post",
           secure: false,
           urlPathForActions: "api",
           urlPathForFiles: "public",

--- a/__tests__/servers/web/rawBody.ts
+++ b/__tests__/servers/web/rawBody.ts
@@ -21,7 +21,7 @@ jest.mock("./../../../src/config/servers/web.ts", () => ({
         return {
           enabled: true,
           saveRawBody: true,
-          automaticRoutes: "post",
+          automaticRoutes: ["post"],
           secure: false,
           urlPathForActions: "api",
           urlPathForFiles: "public",

--- a/__tests__/servers/web/rawBody.ts
+++ b/__tests__/servers/web/rawBody.ts
@@ -27,8 +27,6 @@ jest.mock("./../../../src/config/servers/web.ts", () => ({
           rootEndpointType: "file",
           port: 18080 + parseInt(process.env.JEST_WORKER_ID || "0"),
           matchExtensionMime: true,
-          simpleRouting: true,
-          queryRouting: true,
           metadataOptions: {
             serverInformation: true,
             requesterInformation: false,

--- a/__tests__/servers/web/returnErrorCodes.ts
+++ b/__tests__/servers/web/returnErrorCodes.ts
@@ -26,8 +26,6 @@ jest.mock("./../../../src/config/servers/web.ts", () => ({
           rootEndpointType: "file",
           port: 18080 + parseInt(process.env.JEST_WORKER_ID || "0"),
           matchExtensionMime: true,
-          simpleRouting: true,
-          queryRouting: true,
           metadataOptions: {
             serverInformation: true,
             requesterInformation: false,

--- a/__tests__/servers/web/routes/deepRoutes.ts
+++ b/__tests__/servers/web/routes/deepRoutes.ts
@@ -17,8 +17,6 @@ jest.mock("./../../../../src/config/servers/web.ts", () => ({
           rootEndpointType: "file",
           port: 18080 + parseInt(process.env.JEST_WORKER_ID || "0"),
           matchExtensionMime: true,
-          simpleRouting: true,
-          queryRouting: true,
           metadataOptions: {
             serverInformation: true,
             requesterInformation: false,

--- a/__tests__/servers/web/routes/veryDeepRoutes.ts
+++ b/__tests__/servers/web/routes/veryDeepRoutes.ts
@@ -17,8 +17,6 @@ jest.mock("./../../../../src/config/servers/web.ts", () => ({
           rootEndpointType: "file",
           port: 18080 + parseInt(process.env.JEST_WORKER_ID || "0"),
           matchExtensionMime: true,
-          simpleRouting: true,
-          queryRouting: true,
           metadataOptions: {
             serverInformation: true,
             requesterInformation: false,

--- a/__tests__/servers/web/web.ts
+++ b/__tests__/servers/web/web.ts
@@ -17,6 +17,7 @@ const toJson = async (string) => {
 
 describe("Server: Web", () => {
   beforeAll(async () => {
+    process.env.AUTOMATIC_ROUTES = "head,get,post,put,delete";
     await actionhero.start();
     url = "http://localhost:" + config.servers.web.port;
   });

--- a/src/actions/swagger.ts
+++ b/src/actions/swagger.ts
@@ -64,11 +64,6 @@ export class Swagger extends Action {
           .replace("/v:apiVersion", "")
           .replace(/\/:(\w*)/, "/{$1}");
 
-        // in simpleRouting is enabled, only show the "post" verb for this action, not all 5
-        if (config.servers.web.simpleRouting && method !== "get") {
-          return;
-        }
-
         swaggerPaths[formattedPath] = swaggerPaths[formattedPath] || {};
         swaggerPaths[formattedPath][method] = {
           tags: [tag],

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -1,7 +1,11 @@
 export const DEFAULT = {
   routes: (config) => {
     return {
-      get: [{ path: "/status", action: "status" }],
+      get: [
+        { path: "/status", action: "status" },
+        { path: "/swagger", action: "swagger" },
+        { path: "/createChatRoom", action: "createChatRoom" },
+      ],
 
       /* ---------------------
       For web clients (http and https) you can define an optional RESTful mapping to help route requests to actions.

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -1,9 +1,9 @@
 export const DEFAULT = {
   routes: (config) => {
     return {
-      /* ---------------------
-      routes.js
+      get: [{ path: "/status", action: "status" }],
 
+      /* ---------------------
       For web clients (http and https) you can define an optional RESTful mapping to help route requests to actions.
       If the client doesn't specify and action in a param, and the base route isn't a named action, the action will attempt to be discerned from this routes.js file.
 

--- a/src/config/servers/web.ts
+++ b/src/config/servers/web.ts
@@ -39,8 +39,12 @@ export const DEFAULT = {
         //  Visitors can always visit /api and /public as normal
         rootEndpointType: "file",
         // In addition to what's defined in config/routes.ts, should we make a route for every action?  Useful for debugging or simple APIs.
-        // automaticRoutes should a be comma-separated list of HTTP verbs, ie: null (default), 'get', 'post', 'get,put', 'get,post,put', etc.
-        automaticRoutes: process.env.AUTOMATIC_ROUTES,
+        // automaticRoutes should an array of strings - HTTP verbs, ie: [] (default), ['get'], ['post'], ['get','put'], ['get','post','put'], etc.
+        automaticRoutes: process.env.AUTOMATIC_ROUTES
+          ? process.env.AUTOMATIC_ROUTES.split(",")
+              .map((v) => v.trim())
+              .map((v) => v.toLowerCase())
+          : [],
         // The cache or (if etags are enabled) next-revalidation time to be returned for all flat files served from /public; defined in seconds
         flatFileCacheDuration: 60,
         // Add an etag header to requested flat files which acts as fingerprint that changes when the file is updated;

--- a/src/config/servers/web.ts
+++ b/src/config/servers/web.ts
@@ -38,10 +38,9 @@ export const DEFAULT = {
         // When visiting the root URL, should visitors see 'api' or 'file'?
         //  Visitors can always visit /api and /public as normal
         rootEndpointType: "file",
-        // simple routing also adds an 'all' route which matches /api/:action for all actions
-        simpleRouting: true,
-        // queryRouting allows an action to be defined via a URL param, ie: /api?action=:action
-        queryRouting: true,
+        // In addition to what's defined in config/routes.ts, should we make a route for every action?  Useful for debugging or simple APIs.
+        // automaticRoutes should a be comma-separated list of HTTP verbs, ie: null (default), 'get', 'post', 'get,put', 'get,post,put', etc.
+        automaticRoutes: process.env.AUTOMATIC_ROUTES,
         // The cache or (if etags are enabled) next-revalidation time to be returned for all flat files served from /public; defined in seconds
         flatFileCacheDuration: 60,
         // Add an etag header to requested flat files which acts as fingerprint that changes when the file is updated;

--- a/src/initializers/routes.ts
+++ b/src/initializers/routes.ts
@@ -206,22 +206,28 @@ export class Routes extends Initializer {
 
       api.params.postVariables = utils.arrayUnique(api.params.postVariables);
 
-      if (config.servers.web && config.servers.web.simpleRouting === true) {
-        const simplePaths = [];
-        for (const action in api.actions.actions) {
-          simplePaths.push("/" + action);
-          for (v in api.routes.verbs) {
-            verb = api.routes.verbs[v];
+      if (config.servers.web && config.servers.web.automaticRoutes) {
+        const verbs = config.servers.web.automaticRoutes
+          .split(",")
+          .map((v) => v.trim())
+          .map((v) => v.toLowerCase());
+
+        verbs.forEach((verb) => {
+          if (!api.routes.verbs.includes(verb)) {
+            throw new Error(`${verb} is not an HTTP verb`);
+          }
+
+          log(
+            `creating routes automatically for all actions to ${verb} HTTP verb`
+          );
+
+          for (const action in api.actions.actions) {
             route.registerRoute(verb, "/" + action, action, null);
           }
-        }
-        log(
-          `${simplePaths.length} simple routes loaded from action names`,
-          "debug"
-        );
-
-        log("routes:", "debug", api.routes.routes);
+        });
       }
+
+      log("routes:", "debug", api.routes.routes);
     };
 
     api.routes.loadRoutes();

--- a/src/initializers/routes.ts
+++ b/src/initializers/routes.ts
@@ -79,7 +79,11 @@ export class Routes extends Initializer {
       }
     };
 
-    api.routes.matchURL = (pathParts, match, matchTrailingPathParts) => {
+    api.routes.matchURL = (
+      pathParts,
+      match: string,
+      matchTrailingPathParts: boolean
+    ) => {
       const response = { match: false, params: {} };
       const matchParts = match.split("/");
       let regexp = "";
@@ -172,8 +176,8 @@ export class Routes extends Initializer {
         }
       }
 
-      let v;
-      let verb;
+      let v: string;
+      let verb: string;
       for (const i in rawRoutes) {
         const method = i.toLowerCase();
         for (const j in rawRoutes[i]) {
@@ -206,13 +210,11 @@ export class Routes extends Initializer {
 
       api.params.postVariables = utils.arrayUnique(api.params.postVariables);
 
-      if (config.servers.web && config.servers.web.automaticRoutes) {
-        const verbs = config.servers.web.automaticRoutes
-          .split(",")
-          .map((v) => v.trim())
-          .map((v) => v.toLowerCase());
-
-        verbs.forEach((verb) => {
+      if (
+        config.servers.web &&
+        Array.isArray(config.servers.web.automaticRoutes)
+      ) {
+        config.servers.web.automaticRoutes.forEach((verb: string) => {
           if (!api.routes.verbs.includes(verb)) {
             throw new Error(`${verb} is not an HTTP verb`);
           }

--- a/src/servers/web.ts
+++ b/src/servers/web.ts
@@ -713,16 +713,11 @@ export class WebServer extends Server {
         connection.rawConnection.params.files = files;
         this.fillParamsFromWebRequest(connection, files);
         this.fillParamsFromWebRequest(connection, fields);
-
-        if (this.config.queryRouting !== true) {
-          connection.params.action = null;
-        }
+        connection.params.action = null;
         api.routes.processRoute(connection, pathParts);
         return requestMode;
       } else {
-        if (this.config.queryRouting !== true) {
-          connection.params.action = null;
-        }
+        connection.params.action = null;
         api.routes.processRoute(connection, pathParts);
         return requestMode;
       }


### PR DESCRIPTION
Per the discussion in https://github.com/actionhero/actionhero/discussions/1579, Actionhero is removing the options `config.servers.web.simpleRouting` and `config.servers.web.queryRouting`.  These options were confusing, and generally conflicted with the `config/routes.ts` file.  We want to be clear to new users that the "right" way to define the routes for your Actionhero APIs is in `/config/routes.ts`.

That said, there are times when you may need to quickly build routes automatically from your actions, like when testing or deploying this core Actionhero project directly 😁.  For those cases, this PR adds a new option, `config.servers.web.automaticRoutes`.  This new option is similar-ish to the old `automaticRoutes` option, but differs in a few key ways:
* disabled by default.  New users will not get confused about why actions are showing up automatically
* can support some/many HTTP verbs.  The verb(s) you want are now declarative, ie:
  * `config.servers.web.automaticRoutes = ['get']`
  * `config.servers.web.automaticRoutes = ['get', 'post', 'head']`

For newly generated Actionhero Projects, we will start with your `config/routes.ts` file including a `get` entry for the Status, Swagger, and CreateChatRoom actions, so the examples continue to work