### PR TITLE
Actions can return responses to determine response types

### DIFF
--- a/__tests__/actions/swagger.ts
+++ b/__tests__/actions/swagger.ts
@@ -17,7 +17,7 @@ describe("Action", () => {
       const { paths, basePath, host } = await specHelper.runAction("swagger");
       expect(basePath).toBe("/api/");
       expect(host).toMatch(/localhost/);
-      expect(Object.keys(paths).length).toEqual(7); // 7 actions
+      expect(Object.keys(paths).length).toEqual(8); // 8 actions
     });
   });
 });

--- a/__tests__/core/api.ts
+++ b/__tests__/core/api.ts
@@ -1,4 +1,12 @@
-import { config, api, Process, Action, specHelper } from "./../../src/index";
+import {
+  config,
+  api,
+  Process,
+  Action,
+  specHelper,
+  UnwrapPromise,
+  AssertEqualType,
+} from "./../../src/index";
 
 const actionhero = new Process();
 
@@ -63,8 +71,8 @@ describe("Core", () => {
             description: "I am a test",
             version: 1,
             outputExample: {},
-            run: async (data) => {
-              data.response.version = 1;
+            run: async () => {
+              return { version: 1 };
             },
           },
           //@ts-ignore
@@ -73,8 +81,8 @@ describe("Core", () => {
             description: "I am a test",
             version: 2,
             outputExample: {},
-            run: async (data) => {
-              data.response.version = 2;
+            run: async () => {
+              return { version: 2 };
             },
           },
           //@ts-ignore
@@ -202,6 +210,28 @@ describe("Core", () => {
         expect(() => badAction.validate()).toThrow(
           "input `apiVersion` in action `bad` is a reserved param"
         );
+      });
+
+      test("the return types of actions can be imported", async () => {
+        const { RandomNumber } = await import("../../src/actions/randomNumber");
+        type ResponseType = UnwrapPromise<typeof RandomNumber.prototype.run>;
+
+        // now that we know the types, we can enforce that new objects match the type
+        const responsePayload: ResponseType = {
+          randomNumber: 1,
+          stringRandomNumber: "some string",
+        };
+
+        const responsePartial: ResponseType["randomNumber"] = 2;
+
+        // <AssertEqualType> will fail compilation if the types are not equal
+        const typeMatch: AssertEqualType<
+          typeof responsePayload,
+          ResponseType
+        > = true;
+
+        expect(typeMatch).toBe(true);
+        expect(responsePartial).toBe(2);
       });
     });
 

--- a/__tests__/integration/sendFile.ts
+++ b/__tests__/integration/sendFile.ts
@@ -1,0 +1,25 @@
+import * as request from "request-promise-native";
+import * as fs from "fs";
+import { Process, config } from "./../../src/index";
+
+const actionhero = new Process();
+let url;
+
+describe("Server: sendFile", () => {
+  beforeAll(async () => {
+    process.env.AUTOMATIC_ROUTES = "get";
+    await actionhero.start();
+    url = "http://localhost:" + config.servers.web.port;
+  });
+
+  afterAll(async () => {
+    await actionhero.stop();
+  });
+
+  test("Server should sendFile", async () => {
+    const stats = fs.statSync(__dirname + "/../../public/logo/actionhero.png");
+    const body = await request.get(url + "/api/sendFile");
+    expect(stats.size).toBeGreaterThanOrEqual(body.length);
+    expect(body).toContain("PNG");
+  });
+});

--- a/src/actions/cacheTest.ts
+++ b/src/actions/cacheTest.ts
@@ -10,14 +10,17 @@ export class CacheTest extends Action {
         required: true,
         formatter: this.stringFormatter,
         validator: this.stringValidator,
+        type: "string",
       },
 
       value: {
         required: true,
         formatter: this.stringFormatter,
         validator: this.stringValidator,
+        type: "string",
       },
     };
+
     this.outputExample = {
       cacheTestResults: {
         saveResp: true,
@@ -46,15 +49,17 @@ export class CacheTest extends Action {
     }
   }
 
-  async run({ params, response }) {
+  async run({ params }) {
     const key = `cacheTest_${params.key}`;
     const value = params.value;
 
-    response.cacheTestResults = {
-      saveResp: await cache.save(key, value, 5000),
-      sizeResp: await cache.size(),
-      loadResp: await cache.load(key),
-      deleteResp: await cache.destroy(key),
+    return {
+      cacheTestResults: {
+        saveResp: await cache.save(key, value, 5000),
+        sizeResp: await cache.size(),
+        loadResp: await cache.load(key),
+        deleteResp: await cache.destroy(key),
+      },
     };
   }
 }

--- a/src/actions/cacheTest.ts
+++ b/src/actions/cacheTest.ts
@@ -10,14 +10,12 @@ export class CacheTest extends Action {
         required: true,
         formatter: this.stringFormatter,
         validator: this.stringValidator,
-        type: "string",
       },
 
       value: {
         required: true,
         formatter: this.stringFormatter,
         validator: this.stringValidator,
-        type: "string",
       },
     };
 
@@ -49,7 +47,7 @@ export class CacheTest extends Action {
     }
   }
 
-  async run({ params }) {
+  async run({ params }: { params: { key: string; value: string } }) {
     const key = `cacheTest_${params.key}`;
     const value = params.value;
 

--- a/src/actions/createChatRoom.ts
+++ b/src/actions/createChatRoom.ts
@@ -12,7 +12,7 @@ export class CreateChatRoom extends Action {
     };
   }
 
-  async run({ params }) {
+  async run({ params }: { params: { name: string } }) {
     return { didCreate: await chatRoom.add(params.name) };
   }
 }

--- a/src/actions/createChatRoom.ts
+++ b/src/actions/createChatRoom.ts
@@ -12,7 +12,7 @@ export class CreateChatRoom extends Action {
     };
   }
 
-  async run({ params, response }) {
-    response.didCreate = await chatRoom.add(params.name);
+  async run({ params }) {
+    return { didCreate: await chatRoom.add(params.name) };
   }
 }

--- a/src/actions/randomNumber.ts
+++ b/src/actions/randomNumber.ts
@@ -1,5 +1,4 @@
-import { ActionProcessor } from "../classes/actionProcessor";
-import { api, Action } from "./../index";
+import { Action } from "./../index";
 
 export class RandomNumber extends Action {
   constructor() {

--- a/src/actions/randomNumber.ts
+++ b/src/actions/randomNumber.ts
@@ -1,3 +1,4 @@
+import { ActionProcessor } from "../classes/actionProcessor";
 import { api, Action } from "./../index";
 
 export class RandomNumber extends Action {
@@ -8,11 +9,14 @@ export class RandomNumber extends Action {
     this.outputExample = { randomNumber: 0.123 };
   }
 
-  async run({ connection, response }) {
-    response.randomNumber = Math.random();
-    response.stringRandomNumber = connection.localize([
+  async run({ connection }) {
+    const randomNumber = Math.random();
+    const stringRandomNumber: string = connection.localize([
       "Your random number is {{randomNumber}}",
-      response,
+      // @ts-ignore
+      { randomNumber },
     ]);
+
+    return { randomNumber, stringRandomNumber };
   }
 }

--- a/src/actions/sendFile.ts
+++ b/src/actions/sendFile.ts
@@ -1,0 +1,15 @@
+import { Action, Connection } from "../index";
+
+export class SendFile extends Action {
+  constructor() {
+    super();
+    this.name = "sendFile";
+    this.description = "I send a file though an action";
+    this.outputExample = {};
+  }
+
+  async run(data: { connection: Connection; toRender: boolean }) {
+    await data.connection.sendFile("logo/actionhero.png");
+    data.toRender = false;
+  }
+}

--- a/src/actions/sleepTest.ts
+++ b/src/actions/sleepTest.ts
@@ -30,7 +30,7 @@ export class SleepTest extends Action {
     };
   }
 
-  async run({ params }) {
+  async run({ params }: { params: { sleepDuration: number } }) {
     const sleepDuration = params.sleepDuration;
     const sleepStarted = new Date().getTime();
 

--- a/src/actions/sleepTest.ts
+++ b/src/actions/sleepTest.ts
@@ -1,4 +1,4 @@
-import { api, Action } from "./../index";
+import { Action } from "./../index";
 
 function sleep(time: number): Promise<void> {
   return new Promise((resolve) => {
@@ -30,7 +30,7 @@ export class SleepTest extends Action {
     };
   }
 
-  async run({ response, params }) {
+  async run({ params }) {
     const sleepDuration = params.sleepDuration;
     const sleepStarted = new Date().getTime();
 
@@ -38,9 +38,6 @@ export class SleepTest extends Action {
     const sleepEnded = new Date().getTime();
     const sleepDelta = sleepEnded - sleepStarted;
 
-    response.sleepStarted = sleepStarted;
-    response.sleepEnded = sleepEnded;
-    response.sleepDelta = sleepDelta;
-    response.sleepDuration = sleepDuration;
+    return { sleepStarted, sleepEnded, sleepDelta, sleepDuration };
   }
 }

--- a/src/actions/swagger.ts
+++ b/src/actions/swagger.ts
@@ -49,7 +49,25 @@ export class Swagger extends Action {
   }
 
   buildSwaggerPaths() {
-    const swaggerPaths = {};
+    const swaggerPaths: {
+      [path: string]: {
+        [method: string]: {
+          tags: string[];
+          summary: string;
+          consumes: string[];
+          produces: string[];
+          parameters: Array<{
+            in: string;
+            name: string;
+            type: string;
+            required: boolean;
+            default: string | number | boolean;
+          }>;
+          responses: typeof responses;
+          security: string[];
+        };
+      };
+    } = {};
     const tags = [];
 
     Object.keys(api.routes.routes).map((method) => {
@@ -107,10 +125,10 @@ export class Swagger extends Action {
     return { swaggerPaths, tags };
   }
 
-  async run(data) {
+  async run() {
     const { swaggerPaths, tags } = this.buildSwaggerPaths();
 
-    data.response = {
+    return {
       swagger: SWAGGER_VERSION,
       info: {
         description: parentPackageJSON.description,

--- a/src/actions/validationTest.ts
+++ b/src/actions/validationTest.ts
@@ -1,4 +1,4 @@
-import { api, Action } from "./../index";
+import { Action } from "./../index";
 
 export class ValidationTest extends Action {
   constructor() {
@@ -18,7 +18,7 @@ export class ValidationTest extends Action {
     };
   }
 
-  async run({ params, response }) {
-    response.string = params.string;
+  async run({ params }) {
+    return { string: params.string };
   }
 }

--- a/src/actions/validationTest.ts
+++ b/src/actions/validationTest.ts
@@ -18,7 +18,7 @@ export class ValidationTest extends Action {
     };
   }
 
-  async run({ params }) {
+  async run({ params }: { params: { string: string } }) {
     return { string: params.string };
   }
 }

--- a/src/classes/action.ts
+++ b/src/classes/action.ts
@@ -57,7 +57,7 @@ export abstract class Action {
    * The main "do something" method for this action.  It can be `async`.  Usually the goal of this run method is to set properties on `data.response`.  If error is thrown in this method, it will be logged, caught, and appended to `data.response.error`
    * @param data The data about this connection, response, and params.
    */
-  abstract async run(data: ActionProcessor<this>): Promise<ActionResponse>;
+  abstract async run(data): Promise<ActionResponse>;
 
   private defaults() {
     return {

--- a/src/classes/action.ts
+++ b/src/classes/action.ts
@@ -1,5 +1,4 @@
 import { Inputs } from "./inputs";
-import { ActionProcessor } from "./actionProcessor";
 import { api } from "../index";
 
 /**
@@ -57,7 +56,7 @@ export abstract class Action {
    * The main "do something" method for this action.  It can be `async`.  Usually the goal of this run method is to set properties on `data.response`.  If error is thrown in this method, it will be logged, caught, and appended to `data.response.error`
    * @param data The data about this connection, response, and params.
    */
-  abstract async run(data): Promise<ActionResponse>;
+  abstract async run(data: { [key: string]: any }): Promise<ActionResponse>;
 
   private defaults() {
     return {

--- a/src/classes/action.ts
+++ b/src/classes/action.ts
@@ -27,7 +27,7 @@ export abstract class Action {
   /**The version of this Action (default: 1) */
   version: number | string;
   //*An example response payload  (default: {})
-  outputExample: object;
+  outputExample?: object;
   /**The inputs of the Action (default: {}) */
   inputs: Inputs;
   /**The Middleware specific to this Action (default: []).  Middleware is described by the string names of the middleware. */
@@ -57,7 +57,7 @@ export abstract class Action {
    * The main "do something" method for this action.  It can be `async`.  Usually the goal of this run method is to set properties on `data.response`.  If error is thrown in this method, it will be logged, caught, and appended to `data.response.error`
    * @param data The data about this connection, response, and params.
    */
-  abstract async run(data: ActionProcessor): Promise<void>;
+  abstract async run(data: ActionProcessor<this>): Promise<ActionResponse>;
 
   private defaults() {
     return {
@@ -104,3 +104,5 @@ export abstract class Action {
     });
   }
 }
+
+export type ActionResponse = { [key: string]: any } | null | void;

--- a/src/classes/actionProcessor.ts
+++ b/src/classes/actionProcessor.ts
@@ -13,13 +13,15 @@ export class ActionProcessor<ActionClass extends Action> {
   toRender: boolean;
   messageId: number | string;
   params: {
+    action: string;
+    apiVersion: string | number;
     [key: string]: any;
   };
   // params: ActionClass["inputs"];
   missingParams: Array<string>;
   validatorErrors: Array<string | Error>;
   actionStartTime: number;
-  actionTemplate: Action;
+  actionTemplate: ActionClass;
   working: boolean;
   response: {
     [key: string]: any;
@@ -36,7 +38,10 @@ export class ActionProcessor<ActionClass extends Action> {
     this.toProcess = true;
     this.toRender = true;
     this.messageId = connection.messageId || 0;
-    this.params = Object.assign({}, connection.params);
+    this.params = Object.assign(
+      { action: null, apiVersion: null },
+      connection.params
+    );
     this.missingParams = [];
     this.validatorErrors = [];
     this.actionStartTime = null;
@@ -342,6 +347,8 @@ export class ActionProcessor<ActionClass extends Action> {
             api.actions.versions[this.action].length - 1
           ];
       }
+
+      //@ts-ignore
       this.actionTemplate =
         api.actions.actions[this.action][this.params.apiVersion];
     }

--- a/src/classes/connection.ts
+++ b/src/classes/connection.ts
@@ -148,7 +148,7 @@ export class Connection {
   /**
    * Localize a key for this connection's locale.  Keys usually look like `messages.errors.notFound`, and are defined in your locales directory.  Strings can be interpolated as well, connection.localize('the count was {{count}}', {count: 4})
    */
-  localize(message: string) {
+  localize(message: string | string[]) {
     // this.locale will be sourced automatically
     return i18n.localize(message, this);
   }

--- a/src/classes/input.ts
+++ b/src/classes/input.ts
@@ -3,7 +3,6 @@ export interface Input {
   required?: boolean;
   formatter?: Function | string[];
   validator?: Function | string[];
-  type?: string;
   schema?: {
     [key: string]: any;
   };

--- a/src/classes/input.ts
+++ b/src/classes/input.ts
@@ -3,6 +3,7 @@ export interface Input {
   required?: boolean;
   formatter?: Function | string[];
   validator?: Function | string[];
+  type?: string;
   schema?: {
     [key: string]: any;
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,9 @@ export { projectRoot } from "./classes/process/projectRoot";
 export { typescript } from "./classes/process/typescript";
 export { id } from "./classes/process/id";
 
+// export typescript helpers
+export { UnwrapPromise, AssertEqualType } from "./modules/tsUtils";
+
 // API object to hold connections, actions, tasks, initializers, and servers
 import { Api } from "./classes/api";
 

--- a/src/initializers/staticFile.ts
+++ b/src/initializers/staticFile.ts
@@ -38,7 +38,7 @@ export interface StaticFileApi {
 }
 
 /**
- * Countains helpers for returning flies to connections.
+ * Contains helpers for returning flies to connections.
  */
 export class StaticFile extends Initializer {
   constructor() {

--- a/src/modules/tsUtils.ts
+++ b/src/modules/tsUtils.ts
@@ -1,0 +1,2 @@
+export { UnwrapPromise } from "./tsUtils/unwrapPromise";
+export { AssertEqualType } from "./tsUtils/assertEqualType";

--- a/src/modules/tsUtils/assertEqualType.ts
+++ b/src/modules/tsUtils/assertEqualType.ts
@@ -1,0 +1,9 @@
+// from https://2ality.com/2019/07/testing-static-types.html
+
+export type AssertEqualType<T, Expected> = T extends Expected
+  ? Expected extends T
+    ? true
+    : FailingTypeMatchAssertion
+  : FailingTypeMatchAssertion;
+
+export type FailingTypeMatchAssertion = never;

--- a/src/modules/tsUtils/unwrapPromise.ts
+++ b/src/modules/tsUtils/unwrapPromise.ts
@@ -1,0 +1,9 @@
+// from https://www.jpwilliams.dev/how-to-unpack-the-return-type-of-a-promise-in-typescript
+
+export type UnwrapPromise<T> = T extends Promise<infer U>
+  ? U
+  : T extends (...args: any) => Promise<infer U>
+  ? U
+  : T extends (...args: any) => infer U
+  ? U
+  : T;


### PR DESCRIPTION
The preferred way to describe an Action's run method is now by returning an object which you want to send to your consumers.  By doing this, you are building up a Typescript type which can then be used in your API to type-check API responses! 

For example:

```ts
// src/actions/randomNumber.ts
import { Action } from "actionhero";

export class RandomNumber extends Action {
  constructor() {
    super();
    this.name = "randomNumber";
    this.description = "I am an API method which will generate a random number";
    this.outputExample = { randomNumber: 0.123 };
  }

  async run({ connection }) {
    const randomNumber = Math.random();
    const stringRandomNumber: string = connection.localize([
      "Your random number is {{randomNumber}}",
      { randomNumber },
    ]);

    return { randomNumber, stringRandomNumber };
  }
}
```

Now, you can load in the action and inspect the run method's return type:

```ts
const { RandomNumber } = await import("../../src/actions/randomNumber");
type ResponseType = UnwrapPromise<typeof RandomNumber.prototype.run>;

// now that we know the types, we can enforce that new objects match the type
// this is OK!
const responsePayload: ResponseType = {
  randomNumber: 1,
  stringRandomNumber: "some string",
};

// this fails compilation (missing stringRandomNumber):
const responsePayload: ResponseType = {
  randomNumber: 1,
};
```

The type information is also available to your IDE

<img width="625" alt="Screen Shot 2020-10-06 at 4 33 30 PM" src="https://user-images.githubusercontent.com/303226/95271028-b92a4500-07f1-11eb-8ae6-542d32a61898.png">

Setting `data.response` in the action is still possible, but now it will be discouraged by the class Action, which expects the run method to return an object or null. 

Actionhero now includes the helper types `<UnwrapPromise>` and `<AssertEqualType>` for these types of use cases.