### PR TITLE
Use scan to read collections of redis keys and provide getKeys as a generic way to search for redis keys

### DIFF
--- a/__tests__/core/cache.ts
+++ b/__tests__/core/cache.ts
@@ -38,9 +38,9 @@ describe("Core", () => {
     test("cache.keys", async () => {
       await cache.save("otherKey", "abc123");
       const keys = await cache.keys();
-      expect(keys).toEqual([
-        "actionhero:cache:testKey",
+      expect(keys.sort()).toEqual([
         "actionhero:cache:otherKey",
+        "actionhero:cache:testKey",
       ]);
 
       await cache.client().del("actionhero:cache:otherKey");
@@ -49,9 +49,9 @@ describe("Core", () => {
     test("cache.getKeys", async () => {
       await cache.client().set("act:other:namespace:k", 2);
       const keys = await cache.getKeys("act*");
-      expect(keys).toEqual([
-        "actionhero:cache:testKey",
+      expect(keys.sort()).toEqual([
         "act:other:namespace:k",
+        "actionhero:cache:testKey",
       ]);
     });
 

--- a/__tests__/core/cache.ts
+++ b/__tests__/core/cache.ts
@@ -35,6 +35,26 @@ describe("Core", () => {
       expect(value).toEqual("abc123");
     });
 
+    test("cache.keys", async () => {
+      await cache.save("otherKey", "abc123");
+      const keys = await cache.keys();
+      expect(keys).toEqual([
+        "actionhero:cache:testKey",
+        "actionhero:cache:otherKey",
+      ]);
+
+      await cache.client().del("actionhero:cache:otherKey");
+    });
+
+    test("cache.getKeys", async () => {
+      await cache.client().set("act:other:namespace:k", 2);
+      const keys = await cache.getKeys("act*");
+      expect(keys).toEqual([
+        "actionhero:cache:testKey",
+        "act:other:namespace:k",
+      ]);
+    });
+
     test("cache.load failures", async () => {
       try {
         await cache.load("something else");
@@ -229,6 +249,19 @@ describe("Core", () => {
         expect(lockOk).toEqual(true);
         lockOk = await cache.checkLock(key);
         expect(lockOk).toEqual(true);
+      });
+
+      test("cache.locks", async () => {
+        let locks = await cache.locks();
+        expect(locks).toEqual([]);
+
+        await cache.lock(key, 100);
+        locks = await cache.locks();
+        expect(locks).toEqual(["actionhero:lock:testKey"]);
+
+        await cache.unlock(key);
+        locks = await cache.locks();
+        expect(locks).toEqual([]);
       });
 
       test("locks have a TTL and the default will be assumed from config", async () => {

--- a/src/config/redis.ts
+++ b/src/config/redis.ts
@@ -47,6 +47,7 @@ export const DEFAULT = {
 
     return {
       enabled: true,
+      scanCount: 1000,
 
       _toExpand: false,
       client: {


### PR DESCRIPTION
Previous to this PR, `cache.keys()` and `cache.locks()` were using the `keys` redis command.  With large datasets, this can be slow and block other connections from doing work.  The better way is to use the scan command repeatedly with a cursor to not block the server for too long.  

This PR adds `cache.getKeys(pattern:string)` which uses `scan`.  `cache.keys()` and `cache.locks()` have been refactored to use `cache.getKeys`.  

The `cache.clean` method has been updated to accept an optional `pattern` for the keys to remove, as well as use a redis `pipeline` to speed things up.  Rather than make many requests per key, it will make one to delete all the keys it found.

There's a new config option required, `config.redis.scanCount` to provide how many keys we should scan for in each request.   The default is 1000 