### PR TITLE
`cache.keys` can be provided an optionalScopePrefix

### DIFF
--- a/__tests__/core/cache.ts
+++ b/__tests__/core/cache.ts
@@ -35,7 +35,16 @@ describe("Core", () => {
       expect(value).toEqual("abc123");
     });
 
-    test("cache.keys", async () => {
+    test("cache.getKeys", async () => {
+      await cache.client().set("act:other:namespace:k", 2);
+      const keys = await cache.getKeys("act*");
+      expect(keys.sort()).toEqual([
+        "act:other:namespace:k",
+        "actionhero:cache:testKey",
+      ]);
+    });
+
+    test("cache.keys (no prefix)", async () => {
       await cache.save("otherKey", "abc123");
       const keys = await cache.keys();
       expect(keys.sort()).toEqual([
@@ -46,13 +55,12 @@ describe("Core", () => {
       await cache.client().del("actionhero:cache:otherKey");
     });
 
-    test("cache.getKeys", async () => {
-      await cache.client().set("act:other:namespace:k", 2);
-      const keys = await cache.getKeys("act*");
-      expect(keys.sort()).toEqual([
-        "act:other:namespace:k",
-        "actionhero:cache:testKey",
-      ]);
+    test("cache.keys (with prefix)", async () => {
+      await cache.save("otherKey", "abc123");
+      const keys = await cache.keys("test");
+      expect(keys.sort()).toEqual(["actionhero:cache:testKey"]);
+
+      await cache.client().del("actionhero:cache:otherKey");
     });
 
     test("cache.load failures", async () => {

--- a/src/modules/cache.ts
+++ b/src/modules/cache.ts
@@ -70,17 +70,19 @@ export namespace cache {
   /**
    * Returns all the keys in redis which are under this Actionhero namespace.  Potentially very slow.
    */
-  export async function keys(): Promise<Array<string>> {
+  export async function keys(optionalScopePrefix = ""): Promise<Array<string>> {
     // return client().keys(redisPrefix + "*");
-    return getKeys(redisPrefix + "*");
+    return getKeys(redisPrefix + optionalScopePrefix + "*");
   }
 
   /**
    * Returns all the locks in redis which are under this Actionhero namespace.  Potentially slow.
    */
-  export async function locks(): Promise<Array<string>> {
+  export async function locks(
+    optionalScopePrefix = ""
+  ): Promise<Array<string>> {
     // return client().keys(lockPrefix + "*");
-    return getKeys(lockPrefix + "*");
+    return getKeys(lockPrefix + optionalScopePrefix + "*");
   }
 
   /**


### PR DESCRIPTION
From https://github.com/actionhero/actionhero/pull/1611, we can now provide an optional argument `optionalScopePrefix` to `redis.keys()` to limit what keys we search for.

