### PR TITLE
Do not load routes from Actionhero core

### DIFF
--- a/__tests__/core/config.ts
+++ b/__tests__/core/config.ts
@@ -14,8 +14,8 @@ const newConfigFolderPaths = [
 ];
 
 const routeFilesContent = [
-  "export const DEFAULT = {\n  routes: (api) => {\n    return {\n\n      get: [\n        { path: '/api-status', action: 'status' }\n      ]\n\n    }\n  }\n}\n",
-  "export const DEFAULT= {\n  routes: (api) => {\n    return {\n\n      get: [\n        { path: '/random-number', action: 'randomNumber' }\n      ]\n\n    }\n  }\n}\n",
+  "export const DEFAULT = { collection: () => { return { a: 1 } } }",
+  "export const DEFAULT = { collection: () => { return { b: 2 } } }",
 ];
 
 const createRouteFile = async (newConfigFolderPath, routeFileContent) => {
@@ -24,7 +24,7 @@ const createRouteFile = async (newConfigFolderPath, routeFileContent) => {
   } catch (ex) {}
 
   try {
-    const newRoutesFilePath = path.join(newConfigFolderPath, "routes.ts");
+    const newRoutesFilePath = path.join(newConfigFolderPath, "collection.ts");
 
     await promisify(fs.writeFile)(newRoutesFilePath, routeFileContent, {
       encoding: "utf-8",
@@ -34,7 +34,7 @@ const createRouteFile = async (newConfigFolderPath, routeFileContent) => {
 
 const removeRouteFile = async (newConfigFolderPath) => {
   try {
-    const newRoutesFilePath = path.join(newConfigFolderPath, "routes.ts");
+    const newRoutesFilePath = path.join(newConfigFolderPath, "collection.ts");
 
     await promisify(fs.unlink)(newRoutesFilePath);
   } catch (ex) {}
@@ -67,14 +67,9 @@ describe("Core: config folders", () => {
   });
 
   test("routes should be rebuilt and contain both paths", async () => {
-    expect(config.routes).toEqual({
-      get: [
-        { path: "/status", action: "status" },
-        { path: "/swagger", action: "swagger" },
-        { path: "/createChatRoom", action: "createChatRoom" },
-        { path: "/api-status", action: "status" },
-        { path: "/random-number", action: "randomNumber" },
-      ],
+    expect(config.collection).toEqual({
+      a: 1,
+      b: 2,
     });
   });
 });

--- a/src/modules/config.ts
+++ b/src/modules/config.ts
@@ -1,7 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as glob from "glob";
-import * as os from "os";
 import { argv } from "optimist";
 import { utils } from "./utils";
 import { ensureNoTsHeaderFiles } from "./utils/ensureNoTsHeaderFiles";
@@ -86,7 +85,9 @@ export function buildConfig(_startingParams: ConfigInterface = {}) {
     if (f.includes("routes.js") || f.includes("routes.ts")) {
       // We don't want to merge in routes from Actionhero core unless we are running core directly
       // Routes can be loaded by plugins via `registerRoute`
-      if (f.includes(`${os.EOL}node_modules${os.EOL}actionhero${os.EOL}`)) {
+      if (
+        f.includes(`${path.sep}node_modules${path.sep}actionhero${path.sep}`)
+      ) {
         return;
       }
 

--- a/src/modules/config.ts
+++ b/src/modules/config.ts
@@ -83,6 +83,10 @@ export function buildConfig(_startingParams: ConfigInterface = {}) {
   const loadConfigFile = (f: string) => {
     const localConfig = require(f);
     if (f.includes("routes.js") || f.includes("routes.ts")) {
+      // We don't want to merge in routes from Actionhero core unless we are running core directly
+      // Routes can be loaded by plugins via `registerRoute`
+      if (f.includes("node_modules")) return;
+
       let localRoutes: { [key: string]: any } = { routes: {} };
 
       if (localConfig.DEFAULT) {

--- a/src/modules/config.ts
+++ b/src/modules/config.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as glob from "glob";
+import * as os from "os";
 import { argv } from "optimist";
 import { utils } from "./utils";
 import { ensureNoTsHeaderFiles } from "./utils/ensureNoTsHeaderFiles";
@@ -85,7 +86,9 @@ export function buildConfig(_startingParams: ConfigInterface = {}) {
     if (f.includes("routes.js") || f.includes("routes.ts")) {
       // We don't want to merge in routes from Actionhero core unless we are running core directly
       // Routes can be loaded by plugins via `registerRoute`
-      if (f.includes("node_modules")) return;
+      if (f.includes(`${os.EOL}node_modules${os.EOL}actionhero${os.EOL}`)) {
+        return;
+      }
 
       let localRoutes: { [key: string]: any } = { routes: {} };
 


### PR DESCRIPTION
For most options in config, we load default values from the Actionhero package in case you are missing something.  However, we do not want to do this with routes.  This PR ignores all `config/route.ts` files which may exist within `node_modules`