### PR TITLE
Replace `require` with `await import` where possible

### DIFF
--- a/__tests__/core/cli.ts
+++ b/__tests__/core/cli.ts
@@ -9,7 +9,9 @@ import * as isrunning from "is-running";
 
 const testDir = path.join(process.cwd(), "tmp", "actionheroTestProject");
 const binary = "./node_modules/.bin/actionhero";
-const pacakgeJSON = require(path.join(__dirname, "/../../package.json"));
+const pacakgeJSON = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "/../../package.json")).toString()
+);
 
 console.log(`testDir: ${testDir}`);
 

--- a/__tests__/core/staticFile/staticFile.ts
+++ b/__tests__/core/staticFile/staticFile.ts
@@ -1,4 +1,5 @@
 import * as request from "request-promise-native";
+import * as child_process from "child_process";
 import { Process, config, utils, specHelper } from "../../../src/index";
 
 const actionhero = new Process();
@@ -6,7 +7,7 @@ let url;
 
 async function exec(command) {
   return new Promise((resolve, reject) => {
-    require("child_process").exec(command, (error, stdout, stderr) => {
+    child_process.exec(command, (error, stdout, stderr) => {
       if (error) {
         return reject(error);
       }

--- a/__tests__/integration/browser.ts
+++ b/__tests__/integration/browser.ts
@@ -3,8 +3,11 @@
  */
 
 import * as path from "path";
+import * as fs from "fs";
 import { api, Process, config } from "./../../src/index";
-const packageJSON = require(path.join(__dirname, "..", "..", "package.json"));
+const packageJSON = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "..", "..", "package.json")).toString()
+);
 const host = process.env.SELENIUM_TEST_HOST || "localhost";
 
 const actionhero = new Process();

--- a/src/actions/status.ts
+++ b/src/actions/status.ts
@@ -1,8 +1,14 @@
 import { api, id, task, Action, actionheroVersion } from "./../index";
 import * as path from "path";
-const packageJSON = require(path.normalize(
-  path.join(__dirname, "..", "..", "package.json")
-));
+import * as fs from "fs";
+
+const packageJSON = JSON.parse(
+  fs
+    .readFileSync(
+      path.normalize(path.join(__dirname, "..", "..", "package.json"))
+    )
+    .toString()
+);
 
 // These values are probably good starting points, but you should expect to tweak them for your application
 const maxEventLoopDelay = process.env.eventLoopDelay || 10;

--- a/src/bin/actionhero.ts
+++ b/src/bin/actionhero.ts
@@ -118,7 +118,8 @@ const projectRoot = determineProjectRoot();
       }
 
       if (!ExportedClasses) {
-        config.general.paths.cli.forEach(async (cliPath: string) => {
+        for (const i in config.general.paths.cli) {
+          const cliPath = config.general.paths.cli[i];
           p = path.join(cliPath, commands.join(path.sep) + ".js");
           if (fs.existsSync(p)) {
             ExportedClasses = await import(p);
@@ -128,7 +129,7 @@ const projectRoot = determineProjectRoot();
           if (fs.existsSync(p)) {
             ExportedClasses = await import(p);
           }
-        });
+        }
       }
 
       if (!ExportedClasses) {

--- a/src/bin/actionhero.ts
+++ b/src/bin/actionhero.ts
@@ -74,11 +74,9 @@ const projectRoot = determineProjectRoot();
   const handleUnbuiltProject = async (commands: Array<string>) => {
     try {
       // when generating the project from scratch, we cannot rely on the normal initializers
-      const ExportedRunnerClasses = require(path.join(
-        __dirname,
-        "methods",
-        commands.join(path.sep)
-      ));
+      const ExportedRunnerClasses = await import(
+        path.join(__dirname, "methods", commands.join(path.sep))
+      );
 
       if (Object.keys(ExportedRunnerClasses).length > 1) {
         throw new Error("actionhero CLI files should only export one method");
@@ -101,7 +99,7 @@ const projectRoot = determineProjectRoot();
     console.log(`ACTIONHERO COMMAND >> ${commands.join(" ")}`);
     console.log("⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻⁻");
 
-    const { config, Process } = require(path.join(__dirname, "..", "index"));
+    const { config, Process } = await import("../index");
     const actionHeroProcess = new Process();
     await actionHeroProcess.initialize();
 
@@ -111,24 +109,24 @@ const projectRoot = determineProjectRoot();
       let p: string;
       p = path.join(__dirname, "methods", commands.join(path.sep) + ".js");
       if (fs.existsSync(p) && config.general.cliIncludeInternal !== false) {
-        ExportedClasses = require(p);
+        ExportedClasses = await import(p);
       }
 
       p = path.join(__dirname, "methods", commands.join(path.sep) + ".ts");
       if (fs.existsSync(p) && config.general.cliIncludeInternal !== false) {
-        ExportedClasses = require(p);
+        ExportedClasses = await import(p);
       }
 
       if (!ExportedClasses) {
-        config.general.paths.cli.forEach((cliPath: string) => {
+        config.general.paths.cli.forEach(async (cliPath: string) => {
           p = path.join(cliPath, commands.join(path.sep) + ".js");
           if (fs.existsSync(p)) {
-            ExportedClasses = require(p);
+            ExportedClasses = await import(p);
           }
 
           p = path.join(cliPath, commands.join(path.sep) + ".ts");
           if (fs.existsSync(p)) {
-            ExportedClasses = require(p);
+            ExportedClasses = await import(p);
           }
         });
       }
@@ -139,7 +137,7 @@ const projectRoot = determineProjectRoot();
             const pluginPath = config.plugins[pluginName].path;
             p = path.join(pluginPath, "bin", commands.join(path.sep) + ".js");
             if (fs.existsSync(p)) {
-              ExportedClasses = require(p);
+              ExportedClasses = await import(p);
             }
 
             p = path.join(
@@ -149,7 +147,7 @@ const projectRoot = determineProjectRoot();
               commands.join(path.sep) + ".js"
             );
             if (fs.existsSync(p)) {
-              ExportedClasses = require(p);
+              ExportedClasses = await import(p);
             }
           }
         }

--- a/src/bin/methods/generate/plugin.ts
+++ b/src/bin/methods/generate/plugin.ts
@@ -2,13 +2,11 @@ import * as fs from "fs";
 import * as path from "path";
 import { CLI, utils } from "./../../../index";
 
-const PackageJSON = require(path.join(
-  __dirname,
-  "..",
-  "..",
-  "..",
-  "package.json"
-));
+const PackageJSON = JSON.parse(
+  fs
+    .readFileSync(path.join(__dirname, "..", "..", "..", "package.json"))
+    .toString()
+);
 
 export class GeneratePlugin extends CLI {
   constructor() {

--- a/src/bin/methods/help.ts
+++ b/src/bin/methods/help.ts
@@ -47,9 +47,10 @@ export class Help extends CLI {
 
     files = utils.arrayUnique(files);
 
-    files.forEach((f) => {
+    for (const i in files) {
+      const f = files[i];
       try {
-        const ExportedClasses = require(f);
+        const ExportedClasses = await import(f);
         const req = new ExportedClasses[Object.keys(ExportedClasses)[0]]();
         if (
           req.name &&
@@ -63,7 +64,7 @@ export class Help extends CLI {
           methods[req.name] = req;
         }
       } catch (e) {}
-    });
+    }
 
     const methodNames = Object.keys(methods).sort();
 

--- a/src/bin/methods/version.ts
+++ b/src/bin/methods/version.ts
@@ -1,9 +1,13 @@
 import * as path from "path";
+import * as fs from "fs";
+
 // import { CLI } from "./../../index";
 // we need to load each component directly so we don't accidentally source `config... which doesn't exist`
 import { CLI } from "./../../classes/cli";
 
-const packageJSON = require(path.join(__dirname, "/../../../package.json"));
+const packageJSON = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "/../../../package.json")).toString()
+);
 
 export class Version extends CLI {
   constructor() {

--- a/src/classes/action.ts
+++ b/src/classes/action.ts
@@ -4,7 +4,8 @@ import { api } from "../index";
 /**
  * Create a new Actionhero Action. The required properties of an action. These can be defined statically (this.name) or as methods which return a value.
  *```js
- * const { Action } = require('actionhero')
+ * import { Action } from "actionhero";
+ *
  * module.exports = class RandomNumber extends Action {
  *  constructor () {
  *    super()

--- a/src/classes/process.ts
+++ b/src/classes/process.ts
@@ -107,13 +107,14 @@ export class Process {
     initializerFiles = utils.arrayUnique(initializerFiles);
     initializerFiles = utils.ensureNoTsHeaderFiles(initializerFiles);
 
-    initializerFiles.forEach((f) => {
+    for (const i in initializerFiles) {
+      const f = initializerFiles[i];
       const file = path.normalize(f);
       if (require.cache[require.resolve(file)]) {
         delete require.cache[require.resolve(file)];
       }
 
-      let exportedClasses = require(file);
+      let exportedClasses = await import(file);
 
       // allow for old-js style single default exports
       if (typeof exportedClasses === "function") {
@@ -226,7 +227,7 @@ export class Process {
           stopInitializerRankings[initializer.stopPriority].push(stopFunction);
         }
       }
-    });
+    }
 
     // flatten all the ordered initializer methods
     this.loadInitializers = this.flattenOrderedInitializer(

--- a/src/classes/process/actionheroVersion.ts
+++ b/src/classes/process/actionheroVersion.ts
@@ -1,11 +1,10 @@
 import * as path from "path";
+import * as fs from "fs";
 
-const packageJson = require(path.join(
-  __dirname,
-  "..",
-  "..",
-  "..",
-  "package.json"
-));
+const packageJson = JSON.parse(
+  fs
+    .readFileSync(path.join(__dirname, "..", "..", "..", "package.json"))
+    .toString()
+);
 
 export const actionheroVersion = packageJson.version;

--- a/src/classes/task.ts
+++ b/src/classes/task.ts
@@ -3,7 +3,8 @@ import { Inputs } from "./inputs";
 /**
  * Create a new Actionhero Task. The required properties of an task. These can be defined statically (this.name) or as methods which return a value.
  * ```js
- * const { Task, api, log } = require('actionhero')
+ * import { Task, api, log } from "actionhero"
+ *
  * module.exports = class SayHello extends Task {
  *  constructor () {
  *   super()

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -1,8 +1,13 @@
-const path = require("path");
+import * as path from "path";
+import * as fs from "fs";
 
 export const DEFAULT = {
   general: (config) => {
-    const packageJSON = require("./../../package.json");
+    const packageJSON = JSON.parse(
+      fs
+        .readFileSync(path.join(__dirname, "..", "..", "package.json"))
+        .toString()
+    );
 
     return {
       apiVersion: packageJSON.version,

--- a/src/config/redis.ts
+++ b/src/config/redis.ts
@@ -6,6 +6,9 @@ let db = process.env.REDIS_DB || process.env.JEST_WORKER_ID || "0";
 let password = process.env.REDIS_PASSWORD || null;
 const maxBackoff = 1000;
 
+// this cannot be imported as the ioredis types are not exported for --declaration
+const Redis = require("ioredis");
+
 if (process.env.REDIS_URL) {
   const parsed = new URL(process.env.REDIS_URL);
   if (parsed.password) {
@@ -51,17 +54,17 @@ export const DEFAULT = {
 
       _toExpand: false,
       client: {
-        konstructor: require("ioredis"),
+        konstructor: Redis,
         args: [commonArgs],
         buildNew: true,
       },
       subscriber: {
-        konstructor: require("ioredis"),
+        konstructor: Redis,
         args: [commonArgs],
         buildNew: true,
       },
       tasks: {
-        konstructor: require("ioredis"),
+        konstructor: Redis,
         args: [commonArgs],
         buildNew: true,
       },

--- a/src/config/servers/web.ts
+++ b/src/config/servers/web.ts
@@ -1,4 +1,4 @@
-const os = require("os");
+import * as os from "os";
 
 export const DEFAULT = {
   servers: {

--- a/src/initializers/actions.ts
+++ b/src/initializers/actions.ts
@@ -55,7 +55,7 @@ export class Actions extends Initializer {
       let action;
 
       try {
-        let collection = require(fullFilePath);
+        let collection = await import(fullFilePath);
         if (typeof collection === "function") {
           collection = [collection];
         }

--- a/src/initializers/servers.ts
+++ b/src/initializers/servers.ts
@@ -61,7 +61,7 @@ export class Servers extends Initializer {
 
     for (const j in files) {
       const filename = files[j];
-      const ExportedClasses = require(filename);
+      const ExportedClasses = await import(filename);
 
       const exportLen = Object.keys(ExportedClasses).length;
       // we have named exports

--- a/src/modules/specHelper.ts
+++ b/src/modules/specHelper.ts
@@ -61,6 +61,10 @@ export namespace specHelper {
     taskName: string,
     params: object | Array<any>
   ): Promise<{ [key: string]: any }> {
+    if (!api.tasks.tasks[taskName]) {
+      throw new Error(`task ${taskName} not found`);
+    }
+
     return api.tasks.tasks[taskName].run(params);
   }
 

--- a/src/modules/task.ts
+++ b/src/modules/task.ts
@@ -410,7 +410,7 @@ export namespace task {
         api.tasks.middleware
       );
     }
-    api.tasks.loadTasks(true);
+    await api.tasks.loadTasks(true);
   }
 
   async function validateInput(taskName: string, inputs: TaskInputs) {

--- a/templates/boot.js.template
+++ b/templates/boot.js.template
@@ -1,4 +1,4 @@
-/* This file will load, be `require()`d, first in the actionhero binary.
+/* This file will load, be required, first in the actionhero binary.
    Anything that needed loaded or run BEFORE actionhero starts can be done here.
 
    This file returns a single method that is run immediately after loading.


### PR DESCRIPTION
To Prepare Actionhero for the world of ESM Modules, this PR removes all instances of `require()` with `import` or `await import()`.  

The notable exception is the config system, which still relied on `require()`.  We need to wait for top-level await to be generally available in Node.js to upgrade the config system to use `import`.  This is because we need to be able to statically `import {config} from "actionhero"` and have all files and sub-configs loaded and resolved.  

See https://github.com/actionhero/actionhero/discussions/1571 for more context.