### PR TITLE
Prefer the `end` command when disconnecting from redis

### DIFF
--- a/src/initializers/redis.ts
+++ b/src/initializers/redis.ts
@@ -190,12 +190,12 @@ export class Redis extends Initializer {
     const keys = Object.keys(api.redis.clients);
     for (const i in keys) {
       const client = api.redis.clients[keys[i]];
-      if (typeof client.quit === "function") {
-        await client.quit();
-        //@ts-ignore
-      } else if (typeof client.end === "function") {
+      //@ts-ignore
+      if (typeof client.end === "function") {
         //@ts-ignore
         await client.end();
+      } else if (typeof client.quit === "function") {
+        await client.quit();
       } else if (typeof client.disconnect === "function") {
         await client.disconnect();
       }

--- a/src/initializers/tasks.ts
+++ b/src/initializers/tasks.ts
@@ -167,7 +167,7 @@ export class Tasks extends Initializer {
     await api.tasks.loadTasks(false);
 
     // we want to start the queue now, so that it's available for other initializers and CLI commands
-    await api.resque.startQueue();
+    if (config.redis.enabled === true) await api.resque.startQueue();
   }
 
   async start(config) {


### PR DESCRIPTION
With `ioredis` "quit" will try to reconnect now.  We want to "end" the connections when shutting down. 