### PR TITLE
Replace up to 5 params in routes for swagger

### DIFF
--- a/src/actions/swagger.ts
+++ b/src/actions/swagger.ts
@@ -80,6 +80,10 @@ export class Swagger extends Action {
         const tag = action.name.split(":")[0];
         const formattedPath = route.path
           .replace("/v:apiVersion", "")
+          .replace(/\/:(\w*)/, "/{$1}")
+          .replace(/\/:(\w*)/, "/{$1}")
+          .replace(/\/:(\w*)/, "/{$1}")
+          .replace(/\/:(\w*)/, "/{$1}")
           .replace(/\/:(\w*)/, "/{$1}");
 
         swaggerPaths[formattedPath] = swaggerPaths[formattedPath] || {};


### PR DESCRIPTION
In routes that contain lots of params, ie `/api/:username/:post/:comment`, swagger doesn't properly replace params after the first one.