### PR TITLE
Enable status action and show more useful errors when redis is disabled

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -1,144 +1,194 @@
 <html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta http-equiv="content-language" content="en" />
+    <meta name="description" content="actionhero.js" />
+    <link href="/public/css/cosmo.css" rel="stylesheet" type="text/css" />
+    <link rel="icon" href="/public/favicon.ico" />
+    <title>actionhero.js</title>
 
-<head>
-  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-  <meta http-equiv="content-language" content="en" />
-  <meta name="description" content="actionhero.js" />
-  <link href='/public/css/cosmo.css' rel='stylesheet' type='text/css'>
-  <link rel="icon" href="/public/favicon.ico">
-  <title>actionhero.js</title>
+    <script
+      type="text/javascript"
+      src="/public/javascript/ActionheroWebsocketClient.min.js"
+    ></script>
+  </head>
 
-  <script type="text/javascript" src="/public/javascript/ActionheroWebsocketClient.min.js"></script>
-</head>
+  <body onload="boot()">
+    <br />
 
-<body onload="boot()">
-
-  <br />
-
-  <div class="container">
-    <div class="row">
-      <div class="col-md-12">
-        <h1>Real-Time Chat with Actionhero</h1>
-        <hr />
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="col-md-4">
-        <div class="card border-primary">
-          <div class="card-header">
-            <h3>Hello,<br /><strong><span id="name"></span></strong></h3>
-            <p style="font-size: 10px"><em>fingerprint: <span id="fingerprint" /></em></p>
-          </div>
-          <div class="card-body">
-            <form id="messageForm" class="form-inline">
-              <div class="form-group">
-                <input type="text" class="form-control" id="message" placeholder="Your Message">
-              </div>
-              <button id="submitButton" type="submit" class="btn btn-primary">Send Message</button>
-            </form>
-          </div>
+    <div class="container">
+      <div class="row">
+        <div class="col-md-12">
+          <h1>Real-Time Chat with Actionhero</h1>
+          <hr />
         </div>
       </div>
 
-      <div class="col-md-8">
-        <div class="list-group" id="chatBox" />
+      <div class="row">
+        <div class="col-md-4">
+          <div class="card border-primary">
+            <div class="card-header">
+              <h3>
+                Hello,<br /><strong><span id="name"></span></strong>
+              </h3>
+              <p style="font-size: 10px">
+                <em>fingerprint: <span id="fingerprint" /></em>
+              </p>
+            </div>
+            <div class="card-body">
+              <form id="messageForm" class="form-inline">
+                <div class="form-group">
+                  <input
+                    type="text"
+                    class="form-control"
+                    id="message"
+                    placeholder="Your Message"
+                  />
+                </div>
+                <button id="submitButton" type="submit" class="btn btn-primary">
+                  Send Message
+                </button>
+              </form>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-md-8">
+          <div class="list-group" id="chatBox" />
+        </div>
       </div>
-
     </div>
-  </div>
-</body>
+  </body>
 
-<script>
-  document.getElementById('messageForm').addEventListener('submit', function (e) { e.preventDefault(); sendMessage(); }, false);
-</script>
+  <script>
+    document.getElementById("messageForm").addEventListener(
+      "submit",
+      function (e) {
+        e.preventDefault();
+        sendMessage();
+      },
+      false
+    );
+  </script>
 
-<script type="text/javascript">
-  var client;
-  var boot = function () {
-    client = new ActionheroWebsocketClient();
+  <script type="text/javascript">
+    var client;
+    var boot = function () {
+      client = new ActionheroWebsocketClient();
 
-    client.on('connected', function () { console.log('connected!') })
-    client.on('disconnected', function () { console.log('disconnected :(') })
+      client.on("connected", function () {
+        console.log("connected!");
+      });
+      client.on("disconnected", function () {
+        console.log("disconnected :(");
+      });
 
-    client.on('error', function (error) { console.log('error', error.stack) })
-    client.on('reconnect', function () { console.log('reconnect') })
-    client.on('reconnecting', function () { console.log('reconnecting') })
+      client.on("error", function (error) {
+        console.log("error", error.stack);
+      });
+      client.on("reconnect", function () {
+        console.log("reconnect");
+      });
+      client.on("reconnecting", function () {
+        console.log("reconnecting");
+      });
 
-    // client.on('message',      function(message){ console.log(message) })
+      // client.on('message',      function(message){ console.log(message) })
 
-    client.on('alert', function (message) { alert(JSON.stringify(message)) })
-    client.on('api', function (message) { alert(JSON.stringify(message)) })
+      client.on("alert", function (message) {
+        alert(JSON.stringify(message));
+      });
+      client.on("api", function (message) {
+        alert(JSON.stringify(message));
+      });
 
-    client.on('welcome', function (message) { appendMessage(message); })
-    client.on('say', function (message) { appendMessage(message); })
+      client.on("welcome", function (message) {
+        appendMessage(message);
+      });
+      client.on("say", function (message) {
+        appendMessage(message);
+      });
 
-    client.connect(function (error, details) {
-      if (error) {
-        console.error(error);
+      client.connect(function (error, details) {
+        if (error) {
+          console.error(error);
+        } else {
+          client.action("createChatRoom", { name: "defaultRoom" }, function (
+            data
+          ) {
+            if (data.error) {
+              globalThis.alert(data.error);
+            } else {
+              client.roomAdd("defaultRoom");
+              document.getElementById("name").innerHTML =
+                '<span style="color:#' +
+                intToARGB(hashCode(client.id)) +
+                '">' +
+                client.id +
+                "</span>";
+              document.getElementById("fingerprint").innerHTML =
+                client.fingerprint;
+            }
+          });
+        }
+      });
+    };
+
+    var appendMessage = function (message) {
+      var s = "";
+
+      if (message.welcome != null) {
+        s += "<br />";
+        s += '<div align="center">*** ' + message.welcome + " ***</div>";
+        s +=
+          '<div align="center"><img src="/public/logo/actionhero.png" width="100" /></div>';
       } else {
-        client.action('createChatRoom', { name: 'defaultRoom' }, function (data) {
-          client.roomAdd("defaultRoom");
-          document.getElementById("name").innerHTML = "<span style=\"color:#" + intToARGB(hashCode(client.id)) + "\">" + client.id + "</span>";
-          document.getElementById("fingerprint").innerHTML = client.fingerprint;
-        });
+        s +=
+          '<a href="#" class="list-group-item list-group-item-action flex-column align-items-start">';
+        s += '  <div class="d-flex w-100 justify-content-between">';
+        s +=
+          '    <h5 class="mb-1" style="color:#' +
+          intToARGB(hashCode(message.from)) +
+          '">' +
+          message.from +
+          "</h5>";
+        s += "    <small>" + formatTime(message.sentAt) + "</small>";
+        s += "  </div>";
+        s += '  <p class="mb-1">' + message.message + "</p>";
+        s += "</a >";
       }
-    });
 
-  }
+      var div = document.getElementById("chatBox");
+      div.innerHTML = s + div.innerHTML;
+    };
 
-  var appendMessage = function (message) {
-    var s = "";
+    var sendMessage = function () {
+      var div = document.getElementById("message");
+      var message = div.value;
+      div.value = "";
+      client.say(client.rooms[0], message);
+    };
 
-    if (message.welcome != null) {
+    var formatTime = function (timestamp) {
+      return new Date(timestamp).toLocaleTimeString();
+    };
 
-      s += '<br />'
-      s += "<div align=\"center\">*** " + message.welcome + " ***</div>";
-      s += "<div align=\"center\"><img src=\"/public/logo/actionhero.png\" width=\"100\" /></div>";
-
-    } else {
-
-      s += '<a href="#" class="list-group-item list-group-item-action flex-column align-items-start">';
-      s += '  <div class="d-flex w-100 justify-content-between">';
-      s += '    <h5 class="mb-1" style="color:#' + intToARGB(hashCode(message.from)) + "\">" + message.from + '</h5>';
-      s += '    <small>' + formatTime(message.sentAt) + '</small>';
-      s += '  </div>';
-      s += '  <p class="mb-1">' + message.message + '</p>';
-      s += '</a >';
-
+    function hashCode(str) {
+      // java String#hashCode
+      var hash = 0;
+      for (var i = 0; i < str.length; i++) {
+        hash = str.charCodeAt(i) + ((hash << 5) - hash);
+      }
+      return hash;
     }
 
-    var div = document.getElementById("chatBox");
-    div.innerHTML = s + div.innerHTML;
-  }
-
-  var sendMessage = function () {
-    var div = document.getElementById("message");
-    var message = div.value;
-    div.value = "";
-    client.say(client.rooms[0], message);
-  }
-
-  var formatTime = function (timestamp) {
-    return new Date(timestamp).toLocaleTimeString()
-  }
-
-  function hashCode(str) { // java String#hashCode
-    var hash = 0;
-    for (var i = 0; i < str.length; i++) {
-      hash = str.charCodeAt(i) + ((hash << 5) - hash);
+    function intToARGB(i) {
+      var color =
+        ((i >> 24) & 0xff).toString(16) +
+        ((i >> 16) & 0xff).toString(16) +
+        ((i >> 8) & 0xff).toString(16) +
+        (i & 0xff).toString(16);
+      return color.substring(0, 6);
     }
-    return hash;
-  }
-
-  function intToARGB(i) {
-    var color =
-      ((i >> 24) & 0xFF).toString(16) +
-      ((i >> 16) & 0xFF).toString(16) +
-      ((i >> 8) & 0xFF).toString(16) +
-      (i & 0xFF).toString(16);
-    return color.substring(0, 6);
-  }
-</script>
-
+  </script>
 </html>

--- a/src/modules/chatRoom.ts
+++ b/src/modules/chatRoom.ts
@@ -59,6 +59,14 @@ export namespace chatRoom {
     };
   }
 
+  export function client() {
+    if (config.redis.enabled && api.redis.clients && api.redis.clients.client) {
+      return api.redis.clients.client;
+    } else {
+      throw new Error("redis not connected, chatRoom cannot be used");
+    }
+  }
+
   /**
    * Add a middleware component to connection handling.
    */
@@ -89,7 +97,7 @@ export namespace chatRoom {
    * List all chat rooms created
    */
   export async function list(): Promise<Array<string>> {
-    return api.redis.clients.client.smembers(api.chatRoom.keys.rooms);
+    return client().smembers(api.chatRoom.keys.rooms);
   }
 
   /**
@@ -98,7 +106,7 @@ export namespace chatRoom {
   export async function add(room: string) {
     const found = await chatRoom.exists(room);
     if (found === false) {
-      return api.redis.clients.client.sadd(api.chatRoom.keys.rooms, room);
+      return client().sadd(api.chatRoom.keys.rooms, room);
     } else {
       throw new Error(await config.errors.connectionRoomExists(room));
     }
@@ -115,7 +123,7 @@ export namespace chatRoom {
         room,
         await config.errors.connectionRoomHasBeenDeleted(room)
       );
-      const membersHash = await api.redis.clients.client.hgetall(
+      const membersHash = await client().hgetall(
         api.chatRoom.keys.members + room
       );
 
@@ -123,8 +131,8 @@ export namespace chatRoom {
         await chatRoom.removeMember(id, room, false);
       }
 
-      await api.redis.clients.client.srem(api.chatRoom.keys.rooms, room);
-      await api.redis.clients.client.del(api.chatRoom.keys.members + room);
+      await client().srem(api.chatRoom.keys.rooms, room);
+      await client().del(api.chatRoom.keys.members + room);
     } else {
       throw new Error(await config.errors.connectionRoomNotExist(room));
     }
@@ -134,10 +142,7 @@ export namespace chatRoom {
    * Check if a room exists.
    */
   export async function exists(room: string): Promise<boolean> {
-    const bool = await api.redis.clients.client.sismember(
-      api.chatRoom.keys.rooms,
-      room
-    );
+    const bool = await client().sismember(api.chatRoom.keys.rooms, room);
     let found = false;
     // @ts-ignore
     if (bool === 1 || bool === true) {
@@ -240,7 +245,7 @@ export namespace chatRoom {
     if (connection.rooms.indexOf(room) < 0) {
       const memberDetails = chatRoom.generateMemberDetails(connection);
       connection.rooms.push(room);
-      await api.redis.clients.client.hset(
+      await client().hset(
         api.chatRoom.keys.members + room,
         connection.id,
         JSON.stringify(memberDetails)
@@ -289,10 +294,7 @@ export namespace chatRoom {
     if (connection.rooms.indexOf(room) >= 0) {
       const index = connection.rooms.indexOf(room);
       connection.rooms.splice(index, 1);
-      await api.redis.clients.client.hdel(
-        api.chatRoom.keys.members + room,
-        connection.id
-      );
+      await client().hdel(api.chatRoom.keys.members + room, connection.id);
     }
 
     return true;


### PR DESCRIPTION
This PR adds some improvements when redis is disabled, 
* Skip trying to load the `maxResqueQueueLength` key in the `status` action
* Wrap all uses of redis in the `chatRoom` module with a check to see if redis is enabled.  If not, provide a more meaningful error.  This is also what we do in the `cache` module.