### PR TITLE
Actionhero can be run with ioredis-mock (Redis is always enabled)

### DIFF
--- a/__tests__/integration/ioredis-mock.ts
+++ b/__tests__/integration/ioredis-mock.ts
@@ -1,0 +1,190 @@
+import * as MockIORedis from "ioredis-mock";
+import {
+  api,
+  cache,
+  chatRoom,
+  Process,
+  specHelper,
+  utils,
+  Task,
+  task,
+} from "./../../src/index";
+
+jest.mock("./../../src/config/redis.ts", () => ({
+  __esModule: true,
+  test: {
+    redis: () => {
+      const baseRedis = new MockIORedis();
+      return {
+        _toExpand: false,
+        scanCount: 1000,
+        client: {
+          konstructor: () => baseRedis,
+          args: [],
+          buildNew: false,
+        },
+        subscriber: {
+          konstructor: () => baseRedis.createConnectedClient(),
+          args: [],
+          buildNew: false,
+        },
+        tasks: {
+          konstructor: () => baseRedis.createConnectedClient(),
+          args: [],
+          buildNew: false,
+        },
+      };
+    },
+  },
+}));
+
+jest.mock("./../../src/config/tasks.ts", () => ({
+  __esModule: true,
+  test: {
+    tasks: () => {
+      return {
+        scheduler: true,
+        queues: ["*"],
+        workerLogging: {},
+        schedulerLogging: {},
+        timeout: 100,
+        checkTimeout: 50,
+        minTaskProcessors: 1,
+        maxTaskProcessors: 1,
+        maxEventLoopDelay: 5,
+        stuckWorkerTimeout: 1000 * 60 * 60,
+        connectionOptions: {
+          tasks: {},
+        },
+      };
+    },
+  },
+}));
+
+const actionhero = new Process();
+
+describe("with ioredis-mock", () => {
+  beforeAll(async () => {
+    process.env.AUTOMATIC_ROUTES = "get";
+    await actionhero.start();
+    await api.redis.clients.client.flushdb();
+  });
+
+  afterAll(async () => {
+    await actionhero.stop();
+  });
+
+  test("basic redis operations work and data is shared between the connections", async () => {
+    await api.redis.clients.client.set("__test", "abc");
+    expect(await api.redis.clients.client.get("__test")).toBe("abc");
+    expect(await api.redis.clients.tasks.get("__test")).toBe("abc");
+  });
+
+  test("redis pub-sub works between connections", async () => {
+    let message: string;
+    api.redis.clients.subscriber.subscribe("test-channel");
+    const subscription = api.redis.clients.subscriber.on(
+      "message",
+      (channel, m) => {
+        if (channel === "test-channel") message = m;
+      }
+    );
+
+    await api.redis.clients.client.publish("test-channel", "hello");
+    await utils.sleep(10);
+    expect(message).toBe("hello");
+
+    api.redis.clients.subscriber.unsubscribe("test-channel");
+  });
+
+  test("chat works", async () => {
+    await chatRoom.add("defaultRoom");
+    const client1 = await specHelper.buildConnection();
+    const client2 = await specHelper.buildConnection();
+    client1.verbs("roomAdd", "defaultRoom");
+    client2.verbs("roomAdd", "defaultRoom");
+
+    await utils.sleep(10);
+    await client1.verbs("say", ["defaultRoom", "Hi"]);
+    await utils.sleep(10);
+
+    const { message, room, from } = client2.messages[
+      client2.messages.length - 1
+    ];
+
+    expect(message).toEqual("Hi");
+    expect(room).toEqual("defaultRoom");
+    expect(from).toEqual(client1.id);
+  });
+
+  test("cache works", async () => {
+    await cache.save("testKey", { test: "value" });
+    const { key, value } = await cache.load("testKey");
+    expect(key).toBe("testKey");
+    expect(value).toEqual({ test: "value" });
+  });
+
+  describe("tasks", () => {
+    let taskOutput = [];
+
+    beforeAll(async () => {
+      class RegularTask extends Task {
+        constructor() {
+          super();
+          this.name = "regular";
+          this.description = "task: regular";
+          this.queue = "testQueue";
+          this.frequency = 0;
+        }
+
+        run(params) {
+          taskOutput.push(params.word);
+          return params.word;
+        }
+      }
+
+      api.tasks.tasks.regularTask = new RegularTask();
+      api.tasks.jobs.regularTask = api.tasks.jobWrapper("regularTask");
+    });
+
+    beforeEach(() => {
+      taskOutput = [];
+    });
+
+    afterAll(async () => {
+      delete api.tasks.tasks.regularTask;
+      delete api.tasks.jobs.regularTask;
+    });
+
+    test("tasks work inline (quick)", async () => {
+      const response = await specHelper.runTask("regularTask", {
+        word: "test",
+      });
+      expect(response).toBe("test");
+      expect(taskOutput).toEqual(["test"]);
+    });
+
+    test("tasks work inline (full)", async () => {
+      const response = await specHelper.runFullTask("regularTask", {
+        word: "test",
+      });
+      expect(response).toBe("test");
+      expect(taskOutput).toEqual(["test"]);
+    });
+
+    test("workers and scheduler work", async () => {
+      await task.enqueueIn(1, "regularTask", { word: "test-full" });
+
+      const jobs = await task.allDelayed();
+      const times = Object.keys(jobs);
+      expect(jobs[times[0]][0]).toEqual({
+        args: [{ word: "test-full" }],
+        class: "regularTask",
+        queue: "testQueue",
+      });
+
+      await utils.sleep(1500);
+      expect(taskOutput).toEqual(["test-full"]);
+    }, 10000);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -2807,6 +2807,21 @@
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.0.tgz",
       "integrity": "sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg=="
     },
+    "fengari": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/fengari/-/fengari-0.1.4.tgz",
+      "integrity": "sha512-6ujqUuiIYmcgkGz8MGAdERU57EIluGGPSUgGPTsco657EHa+srq0S3/YUl/r9kx1+D+d4rGfYObd+m8K22gB1g==",
+      "requires": {
+        "readline-sync": "^1.4.9",
+        "sprintf-js": "^1.1.1",
+        "tmp": "^0.0.33"
+      }
+    },
+    "fengari-interop": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/fengari-interop/-/fengari-interop-0.1.2.tgz",
+      "integrity": "sha512-8iTvaByZVoi+lQJhHH9vC+c/Yaok9CwOqNQZN6JrVpjmWwW4dDkeblBXhnHC+BoI6eF4Cy5NKW3z6ICEjvgywQ=="
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -5539,6 +5554,11 @@
         "word-wrap": "~1.2.3"
       }
     },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
     "p-each-series": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
@@ -6827,6 +6847,14 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
     },
     "tmpl": {
       "version": "1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1437,6 +1437,11 @@
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
     },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
+    },
     "array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
@@ -2112,6 +2117,15 @@
         "array-find-index": "^1.0.1"
       }
     },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -2379,6 +2393,71 @@
         }
       }
     },
+    "es5-ext": {
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-map": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
+      }
+    },
+    "es6-set": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "~0.3.5"
+      },
+      "dependencies": {
+        "es6-symbol": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+          "requires": {
+            "d": "1",
+            "es5-ext": "~0.10.14"
+          }
+        }
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "requires": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -2420,6 +2499,15 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
     },
     "eventemitter3": {
       "version": "4.0.7",
@@ -2529,6 +2617,21 @@
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
+        }
+      }
+    },
+    "ext": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "requires": {
+        "type": "^2.0.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
+          "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA=="
         }
       }
     },
@@ -3141,6 +3244,28 @@
         "redis-errors": "^1.2.0",
         "redis-parser": "^3.0.0",
         "standard-as-callback": "^2.0.1"
+      }
+    },
+    "ioredis-mock": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ioredis-mock/-/ioredis-mock-5.1.0.tgz",
+      "integrity": "sha512-6t5ru9KWz6/U2IfvgPKd69MILfnqgz8s5oj3bPsiI50WavHuCTzlAwHF2Yw/MaEeJM5BkBwPIzY0AdTU4bzscw==",
+      "requires": {
+        "array-from": "^2.1.1",
+        "es6-map": "^0.1.5",
+        "es6-set": "^0.1.5",
+        "fengari": "^0.1.4",
+        "fengari-interop": "^0.1.2",
+        "lodash": "^4.17.20",
+        "minimatch": "^3.0.4",
+        "standard-as-callback": "^2.0.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        }
       }
     },
     "ip-regex": {
@@ -5194,6 +5319,11 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -5253,9 +5383,9 @@
       }
     },
     "node-resque": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/node-resque/-/node-resque-8.0.4.tgz",
-      "integrity": "sha512-0vJBjUEjS/sDq9/AejbrfZkGwYtMOz+g3ifUK+pJzv2higCLwP1XP5qYQgNx62wWVn19cf6U1S2HZO44jf8Wcg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/node-resque/-/node-resque-8.1.0.tgz",
+      "integrity": "sha512-2gwz6/LuvgL7Qv+JxwIgqFhciICnMTR915KBceKOBcF8zg9KFZu7gFWewesAE5iSYdXWnMnGLRYkBKYJEIEtDg==",
       "requires": {
         "ioredis": "^4.19.2"
       }
@@ -5749,6 +5879,11 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
+    },
+    "readline-sync": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw=="
     },
     "rechoir": {
       "version": "0.6.2",
@@ -6905,6 +7040,11 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
+    },
+    "type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   },
   "dependencies": {
     "@types/glob": "^7.1.3",
-    "@types/ioredis": "^4.17.7",
-    "@types/node": "^14.14.6",
+    "@types/ioredis": "^4.17.8",
+    "@types/node": "^14.14.7",
     "@types/uuid": "^8.3.0",
     "browser_fingerprint": "^2.0.2",
     "dot-prop": "^6.0.0",
@@ -42,16 +42,17 @@
     "glob": "^7.1.6",
     "i18n": "^0.13.2",
     "ioredis": "^4.19.2",
+    "ioredis-mock": "^5.1.0",
     "is-running": "^2.1.0",
     "mime": "^2.4.6",
-    "node-resque": "^8.0.3",
+    "node-resque": "^8.1.0",
     "optimist": "^0.6.1",
     "primus": "^8.0.0",
     "qs": "^6.9.4",
-    "uglify-js": "^3.11.5",
+    "uglify-js": "^3.11.6",
     "uuid": "^8.3.1",
     "winston": "^3.3.3",
-    "ws": "^7.3.1"
+    "ws": "^7.4.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",
@@ -61,7 +62,7 @@
     "puppeteer": "^5.5.0",
     "request": "^2.88.2",
     "request-promise-native": "^1.0.9",
-    "ts-jest": "^26.4.3",
+    "ts-jest": "^26.4.4",
     "ts-node-dev": "^1.0.0",
     "typedoc": "^0.19.2",
     "typescript": "^4.0.5"

--- a/src/actions/status.ts
+++ b/src/actions/status.ts
@@ -43,23 +43,21 @@ module.exports = class Status extends Action {
     }
 
     let resqueTotalQueueLength = 0;
-    if (config.redis.enabled) {
-      const details = await task.details();
-      let length = 0;
-      Object.keys(details.queues).forEach((q) => {
-        length += details.queues[q].length;
-      });
-      resqueTotalQueueLength = length;
+    const details = await task.details();
+    let length = 0;
+    Object.keys(details.queues).forEach((q) => {
+      length += details.queues[q].length;
+    });
+    resqueTotalQueueLength = length;
 
-      if (length > maxResqueQueueLength) {
-        nodeStatus = connection.localize("Node Unhealthy");
-        problems.push(
-          connection.localize([
-            "Resque Queues over {{maxResqueQueueLength}} jobs",
-            { maxResqueQueueLength: maxResqueQueueLength },
-          ])
-        );
-      }
+    if (length > maxResqueQueueLength) {
+      nodeStatus = connection.localize("Node Unhealthy");
+      problems.push(
+        connection.localize([
+          "Resque Queues over {{maxResqueQueueLength}} jobs",
+          { maxResqueQueueLength: maxResqueQueueLength },
+        ])
+      );
     }
 
     return {

--- a/src/config/redis.ts
+++ b/src/config/redis.ts
@@ -1,6 +1,4 @@
 import { URL } from "url";
-import * as IORedis from "ioredis";
-import * as MockIORedis from "ioredis-mock";
 
 /**
  * This is the standard redis config for Actionhero.
@@ -9,6 +7,8 @@ import * as MockIORedis from "ioredis-mock";
 
 export const DEFAULT = {
   redis: (config) => {
+    const konstructor = require("ioredis");
+
     let host = process.env.REDIS_HOST || "127.0.0.1";
     let port = process.env.REDIS_PORT || 6379;
     let db = process.env.REDIS_DB || process.env.JEST_WORKER_ID || "0";
@@ -46,17 +46,17 @@ export const DEFAULT = {
 
       _toExpand: false,
       client: {
-        konstructor: IORedis,
+        konstructor,
         args: [commonArgs],
         buildNew: true,
       },
       subscriber: {
-        konstructor: IORedis,
+        konstructor,
         args: [commonArgs],
         buildNew: true,
       },
       tasks: {
-        konstructor: IORedis,
+        konstructor,
         args: [commonArgs],
         buildNew: true,
       },
@@ -72,6 +72,7 @@ export const DEFAULT = {
 
 // export const DEFAULT = {
 //   redis: (config) => {
+//     const MockIORedis = require("ioredis-mock");
 //     const baseRedis = new MockIORedis();
 
 //     return {

--- a/src/config/redis.ts
+++ b/src/config/redis.ts
@@ -1,36 +1,28 @@
 import { URL } from "url";
+import * as IORedis from "ioredis";
+import * as MockIORedis from "ioredis-mock";
 
-let host = process.env.REDIS_HOST || "127.0.0.1";
-let port = process.env.REDIS_PORT || 6379;
-let db = process.env.REDIS_DB || process.env.JEST_WORKER_ID || "0";
-let password = process.env.REDIS_PASSWORD || null;
-const maxBackoff = 1000;
-
-// this cannot be imported as the ioredis types are not exported for --declaration
-const Redis = require("ioredis");
-
-if (process.env.REDIS_URL) {
-  const parsed = new URL(process.env.REDIS_URL);
-  if (parsed.password) {
-    password = parsed.password;
-  }
-  if (parsed.hostname) {
-    host = parsed.hostname;
-  }
-  if (parsed.port) {
-    port = parsed.port;
-  }
-  if (parsed.pathname) {
-    db = parsed.pathname.substring(1);
-  }
-}
+/**
+ * This is the standard redis config for Actionhero.
+ * This will use a redis server to persist cache, share chat message between processes, etc.
+ */
 
 export const DEFAULT = {
   redis: (config) => {
-    // konstructor: The redis client constructor method.  All redis methods must be promises
-    // args: The arguments to pass to the constructor
-    // buildNew: is it `new konstructor()` or just `konstructor()`?
+    let host = process.env.REDIS_HOST || "127.0.0.1";
+    let port = process.env.REDIS_PORT || 6379;
+    let db = process.env.REDIS_DB || process.env.JEST_WORKER_ID || "0";
+    let password = process.env.REDIS_PASSWORD || null;
 
+    if (process.env.REDIS_URL) {
+      const parsed = new URL(process.env.REDIS_URL);
+      if (parsed.password) password = parsed.password;
+      if (parsed.hostname) host = parsed.hostname;
+      if (parsed.port) port = parsed.port;
+      if (parsed.pathname) db = parsed.pathname.substring(1);
+    }
+
+    const maxBackoff = 1000;
     const commonArgs = {
       port,
       host,
@@ -54,20 +46,53 @@ export const DEFAULT = {
 
       _toExpand: false,
       client: {
-        konstructor: Redis,
+        konstructor: IORedis,
         args: [commonArgs],
         buildNew: true,
       },
       subscriber: {
-        konstructor: Redis,
+        konstructor: IORedis,
         args: [commonArgs],
         buildNew: true,
       },
       tasks: {
-        konstructor: Redis,
+        konstructor: IORedis,
         args: [commonArgs],
         buildNew: true,
       },
     };
   },
 };
+
+/**
+ * If you do not want to connect to a real redis server, and want to emulate the functionally of redis in-memory, you can use `MockIORedis`
+ * Note that large data sets will be stored in RAM, and not persisted to disk.  Multiple Actionhero processes cannot share cache, chat messages, etc.
+ * Redis Pub/Sub works with this configuration.
+ */
+
+// export const DEFAULT = {
+//   redis: (config) => {
+//     const baseRedis = new MockIORedis();
+
+//     return {
+//       scanCount: 1000,
+
+//       _toExpand: false,
+//       client: {
+//         konstructor: () => baseRedis,
+//         args: [],
+//         buildNew: false,
+//       },
+//       subscriber: {
+//         konstructor: () => baseRedis.createConnectedClient(),
+//         args: [],
+//         buildNew: false,
+//       },
+//       tasks: {
+//         konstructor: () => baseRedis.createConnectedClient(),
+//         args: [],
+//         buildNew: false,
+//       },
+//     };
+//   },
+// };

--- a/src/initializers/chatRoom.ts
+++ b/src/initializers/chatRoom.ts
@@ -28,10 +28,6 @@ export class ChatRoom extends Initializer {
   }
 
   async initialize(config) {
-    if (config.redis.enabled === false) {
-      return;
-    }
-
     api.chatRoom = {
       middleware: {},
       globalMiddleware: [],
@@ -167,10 +163,6 @@ export class ChatRoom extends Initializer {
   }
 
   async start(config) {
-    if (config.redis.enabled === false) {
-      return;
-    }
-
     api.redis.subscriptionHandlers.chat = (message) => {
       if (api.chatRoom) {
         api.chatRoom.incomingMessage(message);

--- a/src/initializers/redis.ts
+++ b/src/initializers/redis.ts
@@ -31,10 +31,6 @@ export class Redis extends Initializer {
   }
 
   async initialize(config) {
-    if (config.redis.enabled === false) {
-      return;
-    }
-
     api.redis = {
       clients: {},
       subscriptionHandlers: {},
@@ -124,8 +120,7 @@ export class Redis extends Initializer {
           log(`Redis connection \`${r}\` reconnecting`, "info");
         });
       } else {
-        api.redis.clients[r] = config.redis[r].konstructor.apply(
-          null,
+        api.redis.clients[r] = config.redis[r].konstructor(
           config.redis[r].args
         );
         api.redis.clients[r].on("error", (error) => {
@@ -134,7 +129,7 @@ export class Redis extends Initializer {
         log(`Redis connection \`${r}\` connected`, "debug");
       }
 
-      await api.redis.clients[r].get("_test");
+      if (r !== "subscriber") await api.redis.clients[r].get("_test");
     }
 
     if (!api.redis.status.subscribed) {
@@ -167,20 +162,12 @@ export class Redis extends Initializer {
   }
 
   async start(config) {
-    if (config.redis.enabled === false) {
-      log("redis is disabled", "notice");
-    } else {
-      await redis.doCluster("api.log", [
-        `actionhero member ${id} has joined the cluster`,
-      ]);
-    }
+    await redis.doCluster("api.log", [
+      `actionhero member ${id} has joined the cluster`,
+    ]);
   }
 
   async stop(config) {
-    if (config.redis.enabled === false) {
-      return;
-    }
-
     await api.redis.clients.subscriber.unsubscribe();
     api.redis.status.subscribed = false;
     await redis.doCluster("api.log", [

--- a/src/initializers/resque.ts
+++ b/src/initializers/resque.ts
@@ -43,8 +43,6 @@ export class Resque extends Initializer {
   }
 
   async initialize(config) {
-    if (config.redis.enabled === false) return;
-
     const resqueOverrides = config.tasks.resque_overrides;
 
     api.resque = {
@@ -56,6 +54,10 @@ export class Resque extends Initializer {
         config.tasks.connectionOptions.tasks,
         {
           redis: api.redis.clients.tasks,
+          pkg:
+            api.redis.clients.tasks?.constructor?.name === "RedisMock"
+              ? "ioredis-mock"
+              : "ioredis",
         }
       ),
 
@@ -263,8 +265,6 @@ export class Resque extends Initializer {
   }
 
   async start(config) {
-    if (config.redis.enabled === false) return;
-
     if (
       config.tasks.minTaskProcessors === 0 &&
       config.tasks.maxTaskProcessors > 0
@@ -277,8 +277,6 @@ export class Resque extends Initializer {
   }
 
   async stop(config) {
-    if (config.redis.enabled === false) return;
-
     await api.resque.stopScheduler();
     await api.resque.stopMultiWorker();
     await api.resque.stopQueue();

--- a/src/initializers/tasks.ts
+++ b/src/initializers/tasks.ts
@@ -167,12 +167,10 @@ export class Tasks extends Initializer {
     await api.tasks.loadTasks(false);
 
     // we want to start the queue now, so that it's available for other initializers and CLI commands
-    if (config.redis.enabled === true) await api.resque.startQueue();
+    await api.resque.startQueue();
   }
 
   async start(config) {
-    if (config.redis.enabled === false) return;
-
     if (config.tasks.scheduler === true) {
       await taskModule.enqueueAllRecurrentTasks();
     }

--- a/src/modules/cache.ts
+++ b/src/modules/cache.ts
@@ -23,7 +23,7 @@ export namespace cache {
   export const lockRetry: number = 100;
 
   export function client() {
-    if (config.redis.enabled && api.redis.clients && api.redis.clients.client) {
+    if (api.redis.clients && api.redis.clients.client) {
       return api.redis.clients.client;
     } else {
       throw new Error("redis not connected, cache cannot be used");

--- a/src/modules/chatRoom.ts
+++ b/src/modules/chatRoom.ts
@@ -60,7 +60,7 @@ export namespace chatRoom {
   }
 
   export function client() {
-    if (config.redis.enabled && api.redis.clients && api.redis.clients.client) {
+    if (api.redis.clients && api.redis.clients.client) {
       return api.redis.clients.client;
     } else {
       throw new Error("redis not connected, chatRoom cannot be used");

--- a/src/modules/specHelper.ts
+++ b/src/modules/specHelper.ts
@@ -80,6 +80,10 @@ export namespace specHelper {
       {
         connection: {
           redis: api.redis.clients.tasks,
+          pkg:
+            api.redis.clients.tasks?.constructor?.name === "RedisMock"
+              ? "ioredis-mock"
+              : "ioredis",
         },
         queues: config.tasks.queues || ["default"],
       },

--- a/templates/package.json.template
+++ b/templates/package.json.template
@@ -10,6 +10,7 @@
     "actionhero": "%%versionNumber%%",
     "ws": "latest",
     "ioredis": "latest",
+    "ioredis-mock": "latest",
     "winston": "latest"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR allows Actionhero to be run with the [`ioredis-mock`](https://github.com/stipsan/ioredis-mock) package.  In this way, we can allow users of Actionhero to use **every** features of the framework, including cache, chat, and tasks, without a Redis server running locally.   This is a breaking change as it removes the `enabled` option on `config.redis`, as Redis is now always enabled, but possibly mocked.

Of course, no data will be persisted or shared between nodes unless you are using a "real" Redis server.  The default configuration of Actionhero (when a new project is generated with `npx actionhero generate`) is to assume that a real Redis server can be reached at `localhost`.  However, we make it easy to change by providing a `ioredis-mock`-based configuration commented out in `config/redis.ts`.

Uses `ioredis-mock` may also be beneficial in your tests. 