### PR TITLE
Test mode still continues to use Typescript

### DIFF
--- a/src/classes/process/typescript.ts
+++ b/src/classes/process/typescript.ts
@@ -26,7 +26,11 @@ function isTypescript(): boolean {
      * Are we running in typescript at the moment?
      * see https://github.com/TypeStrong/ts-node/pull/858 for more details
      */
-    return process[Symbol.for("ts-node.register.instance")] ? true : false;
+    return process[Symbol.for("ts-node.register.instance")] ||
+      (process.env.NODE_ENV === "test" &&
+        process.env.ACTIONHERO_TYPESCRIPT_MODE?.toLowerCase() !== "false")
+      ? true
+      : false;
   } catch (error) {
     console.error(error);
     return false;


### PR DESCRIPTION
Fixes a bug introduced in #1668 - we want to still default to testing Typescript files