### PR TITLE
Type Action and Task responses in specHelper

### DIFF
--- a/__tests__/actions/cacheTest.ts
+++ b/__tests__/actions/cacheTest.ts
@@ -72,13 +72,13 @@ describe("Action", () => {
     });
 
     test("works with correct params", async () => {
-      const { cacheTestResults } = await specHelper.runAction<typeof RunMethod>(
-        "cacheTest",
-        {
-          key: "testKey",
-          value: "abc123",
-        }
-      );
+      const { cacheTestResults, error } = await specHelper.runAction<
+        typeof RunMethod
+      >("cacheTest", {
+        key: "testKey",
+        value: "abc123",
+      });
+      expect(error).toBeFalsy();
       expect(cacheTestResults.saveResp).toEqual(true);
       expect(cacheTestResults.loadResp.value).toEqual("abc123");
       expect(cacheTestResults.deleteResp).toEqual(true);

--- a/__tests__/actions/cacheTest.ts
+++ b/__tests__/actions/cacheTest.ts
@@ -1,8 +1,7 @@
 import { Process, specHelper } from "./../../src/index";
-import { UnwrapPromise } from "../..";
 import { CacheTest } from "../../src/actions/cacheTest";
 
-type ActionResponse = UnwrapPromise<typeof CacheTest.prototype.run>;
+const RunMethod = CacheTest.prototype.run;
 const actionhero = new Process();
 
 describe("Action", () => {
@@ -16,49 +15,64 @@ describe("Action", () => {
     });
 
     test("fails with no params", async () => {
-      const { error } = await specHelper.runAction("cacheTest", {});
+      const { error } = await specHelper.runAction<typeof RunMethod>(
+        "cacheTest",
+        {}
+      );
       expect(error).toEqual(
         "Error: key is a required parameter for this action"
       );
     });
 
     test("fails with just key", async () => {
-      const { error } = await specHelper.runAction("cacheTest", {
-        key: "test key",
-      });
+      const { error } = await specHelper.runAction<typeof RunMethod>(
+        "cacheTest",
+        {
+          key: "test key",
+        }
+      );
       expect(error).toEqual(
         "Error: value is a required parameter for this action"
       );
     });
 
     test("fails with just value", async () => {
-      const { error } = await specHelper.runAction("cacheTest", {
-        value: "abc123",
-      });
+      const { error } = await specHelper.runAction<typeof RunMethod>(
+        "cacheTest",
+        {
+          value: "abc123",
+        }
+      );
       expect(error).toEqual(
         "Error: key is a required parameter for this action"
       );
     });
 
     test("fails with gibberish param", async () => {
-      const { error } = await specHelper.runAction("cacheTest", {
-        thingy: "abc123",
-      });
+      const { error } = await specHelper.runAction<typeof RunMethod>(
+        "cacheTest",
+        {
+          thingy: "abc123",
+        }
+      );
       expect(error).toEqual(
         "Error: key is a required parameter for this action"
       );
     });
 
     test("fails with value shorter than 2 letters", async () => {
-      const { error } = await specHelper.runAction("cacheTest", {
-        key: "abc123",
-        value: "v",
-      });
+      const { error } = await specHelper.runAction<typeof RunMethod>(
+        "cacheTest",
+        {
+          key: "abc123",
+          value: "v",
+        }
+      );
       expect(error).toEqual("Error: inputs should be at least 3 letters long");
     });
 
     test("works with correct params", async () => {
-      const { cacheTestResults }: ActionResponse = await specHelper.runAction(
+      const { cacheTestResults } = await specHelper.runAction<typeof RunMethod>(
         "cacheTest",
         {
           key: "testKey",

--- a/__tests__/actions/cacheTest.ts
+++ b/__tests__/actions/cacheTest.ts
@@ -1,5 +1,8 @@
 import { Process, specHelper } from "./../../src/index";
+import { UnwrapPromise } from "../..";
+import { CacheTest } from "../../src/actions/cacheTest";
 
+type ActionResponse = UnwrapPromise<typeof CacheTest.prototype.run>;
 const actionhero = new Process();
 
 describe("Action", () => {
@@ -55,10 +58,13 @@ describe("Action", () => {
     });
 
     test("works with correct params", async () => {
-      const { cacheTestResults } = await specHelper.runAction("cacheTest", {
-        key: "testKey",
-        value: "abc123",
-      });
+      const { cacheTestResults }: ActionResponse = await specHelper.runAction(
+        "cacheTest",
+        {
+          key: "testKey",
+          value: "abc123",
+        }
+      );
       expect(cacheTestResults.saveResp).toEqual(true);
       expect(cacheTestResults.loadResp.value).toEqual("abc123");
       expect(cacheTestResults.deleteResp).toEqual(true);

--- a/__tests__/actions/randomNumber.ts
+++ b/__tests__/actions/randomNumber.ts
@@ -1,8 +1,7 @@
 import { Process, specHelper } from "./../../src/index";
-import { UnwrapPromise } from "../..";
 import { RandomNumber } from "../../src/actions/randomNumber";
 
-type ActionResponse = UnwrapPromise<typeof RandomNumber.prototype.run>;
+const RunMethod = RandomNumber.prototype.run;
 const actionhero = new Process();
 
 describe("Action", () => {
@@ -18,7 +17,7 @@ describe("Action", () => {
     let firstNumber = null;
 
     test("generates random numbers", async () => {
-      const { randomNumber }: ActionResponse = await specHelper.runAction(
+      const { randomNumber } = await specHelper.runAction<typeof RunMethod>(
         "randomNumber"
       );
       expect(randomNumber).toBeGreaterThan(0);
@@ -27,7 +26,9 @@ describe("Action", () => {
     });
 
     test("is unique / random", async () => {
-      const { randomNumber } = await specHelper.runAction("randomNumber");
+      const { randomNumber } = await specHelper.runAction<typeof RunMethod>(
+        "randomNumber"
+      );
       expect(randomNumber).toBeGreaterThan(0);
       expect(randomNumber).toBeLessThan(1);
       expect(randomNumber).not.toEqual(firstNumber);

--- a/__tests__/actions/randomNumber.ts
+++ b/__tests__/actions/randomNumber.ts
@@ -1,5 +1,8 @@
 import { Process, specHelper } from "./../../src/index";
+import { UnwrapPromise } from "../..";
+import { RandomNumber } from "../../src/actions/randomNumber";
 
+type ActionResponse = UnwrapPromise<typeof RandomNumber.prototype.run>;
 const actionhero = new Process();
 
 describe("Action", () => {
@@ -15,7 +18,9 @@ describe("Action", () => {
     let firstNumber = null;
 
     test("generates random numbers", async () => {
-      const { randomNumber } = await specHelper.runAction("randomNumber");
+      const { randomNumber }: ActionResponse = await specHelper.runAction(
+        "randomNumber"
+      );
       expect(randomNumber).toBeGreaterThan(0);
       expect(randomNumber).toBeLessThan(1);
       firstNumber = randomNumber;

--- a/__tests__/actions/recursiveAction.ts
+++ b/__tests__/actions/recursiveAction.ts
@@ -1,4 +1,8 @@
 import { Process, specHelper } from "./../../src/index";
+import { UnwrapPromise } from "../..";
+import { RecursiveAction } from "../../src/actions/recursiveAction";
+
+type ActionResponse = UnwrapPromise<typeof RecursiveAction.prototype.run>;
 
 const actionhero = new Process();
 
@@ -13,7 +17,9 @@ describe("Action", () => {
     });
 
     test("merges its own response with the randomNumber response", async () => {
-      const response = await specHelper.runAction("recursiveAction");
+      const response: ActionResponse = await specHelper.runAction(
+        "recursiveAction"
+      );
       expect(response.local).toEqual(true);
       expect(response.randomNumber).toBeGreaterThanOrEqual(0);
       expect(response.stringRandomNumber).toMatch(/Your random number is/);

--- a/__tests__/actions/recursiveAction.ts
+++ b/__tests__/actions/recursiveAction.ts
@@ -1,9 +1,7 @@
 import { Process, specHelper } from "./../../src/index";
-import { UnwrapPromise } from "../..";
 import { RecursiveAction } from "../../src/actions/recursiveAction";
 
-type ActionResponse = UnwrapPromise<typeof RecursiveAction.prototype.run>;
-
+const RunMethod = RecursiveAction.prototype.run;
 const actionhero = new Process();
 
 describe("Action", () => {
@@ -17,7 +15,7 @@ describe("Action", () => {
     });
 
     test("merges its own response with the randomNumber response", async () => {
-      const response: ActionResponse = await specHelper.runAction(
+      const response = await specHelper.runAction<typeof RunMethod>(
         "recursiveAction"
       );
       expect(response.local).toEqual(true);

--- a/__tests__/actions/sleepTest.ts
+++ b/__tests__/actions/sleepTest.ts
@@ -1,8 +1,7 @@
 import { Process, specHelper } from "./../../src/index";
-import { UnwrapPromise } from "../..";
 import { SleepTest } from "../../src/actions/sleepTest";
 
-type ActionResponse = UnwrapPromise<typeof SleepTest.prototype.run>;
+const RunMethod = SleepTest.prototype.run;
 const actionhero = new Process();
 
 describe("Action", () => {
@@ -16,14 +15,14 @@ describe("Action", () => {
     });
 
     test("will return data from an async action", async () => {
-      const { sleepDuration }: ActionResponse = await specHelper.runAction(
+      const { sleepDuration } = await specHelper.runAction<typeof RunMethod>(
         "sleepTest"
       );
       expect(sleepDuration).toEqual(1000);
     });
 
     test("can change sleepDuration", async () => {
-      const { sleepDuration }: ActionResponse = await specHelper.runAction(
+      const { sleepDuration } = await specHelper.runAction<typeof RunMethod>(
         "sleepTest",
         {
           sleepDuration: 100,

--- a/__tests__/actions/sleepTest.ts
+++ b/__tests__/actions/sleepTest.ts
@@ -1,5 +1,8 @@
 import { Process, specHelper } from "./../../src/index";
+import { UnwrapPromise } from "../..";
+import { SleepTest } from "../../src/actions/sleepTest";
 
+type ActionResponse = UnwrapPromise<typeof SleepTest.prototype.run>;
 const actionhero = new Process();
 
 describe("Action", () => {
@@ -13,14 +16,19 @@ describe("Action", () => {
     });
 
     test("will return data from an async action", async () => {
-      const { sleepDuration } = await specHelper.runAction("sleepTest");
+      const { sleepDuration }: ActionResponse = await specHelper.runAction(
+        "sleepTest"
+      );
       expect(sleepDuration).toEqual(1000);
     });
 
     test("can change sleepDuration", async () => {
-      const { sleepDuration } = await specHelper.runAction("sleepTest", {
-        sleepDuration: 100,
-      });
+      const { sleepDuration }: ActionResponse = await specHelper.runAction(
+        "sleepTest",
+        {
+          sleepDuration: 100,
+        }
+      );
       expect(sleepDuration).toEqual(100);
     });
   });

--- a/__tests__/actions/status.ts
+++ b/__tests__/actions/status.ts
@@ -1,8 +1,7 @@
 import { Process, specHelper } from "./../../src/index";
-import { UnwrapPromise } from "../..";
 import { Status } from "../../src/actions/status";
 
-type ActionResponse = UnwrapPromise<typeof Status.prototype.run>;
+const RunMethod = Status.prototype.run;
 const actionhero = new Process();
 
 describe("Action", () => {
@@ -16,13 +15,9 @@ describe("Action", () => {
     });
 
     test("returns node status", async () => {
-      const {
-        id,
-        problems,
-        name,
-        //@ts-ignore
-        error,
-      }: ActionResponse = await specHelper.runAction("status");
+      const { id, problems, name, error } = await specHelper.runAction<
+        typeof RunMethod
+      >("status");
       expect(error).toBeUndefined();
       expect(problems).toHaveLength(0);
       expect(id).toEqual(`test-server-${process.env.JEST_WORKER_ID || 0}`);

--- a/__tests__/actions/status.ts
+++ b/__tests__/actions/status.ts
@@ -1,5 +1,8 @@
 import { Process, specHelper } from "./../../src/index";
+import { UnwrapPromise } from "../..";
+import { Status } from "../../src/actions/status";
 
+type ActionResponse = UnwrapPromise<typeof Status.prototype.run>;
 const actionhero = new Process();
 
 describe("Action", () => {
@@ -13,9 +16,13 @@ describe("Action", () => {
     });
 
     test("returns node status", async () => {
-      const { id, problems, name, error } = await specHelper.runAction(
-        "status"
-      );
+      const {
+        id,
+        problems,
+        name,
+        //@ts-ignore
+        error,
+      }: ActionResponse = await specHelper.runAction("status");
       expect(error).toBeUndefined();
       expect(problems).toHaveLength(0);
       expect(id).toEqual(`test-server-${process.env.JEST_WORKER_ID || 0}`);

--- a/__tests__/actions/swagger.ts
+++ b/__tests__/actions/swagger.ts
@@ -1,8 +1,7 @@
 import { Process, specHelper } from "./../../src/index";
-import { UnwrapPromise } from "../..";
 import { Swagger } from "../../src/actions/swagger";
 
-type ActionResponse = UnwrapPromise<typeof Swagger.prototype.run>;
+const RunMethod = Swagger.prototype.run;
 const actionhero = new Process();
 
 describe("Action", () => {
@@ -17,11 +16,9 @@ describe("Action", () => {
     });
 
     test("returns the correct parts", async () => {
-      const {
-        paths,
-        basePath,
-        host,
-      }: ActionResponse = await specHelper.runAction("swagger");
+      const { paths, basePath, host } = await specHelper.runAction<
+        typeof RunMethod
+      >("swagger");
       expect(basePath).toBe("/api/");
       expect(host).toMatch(/localhost/);
       expect(Object.keys(paths).length).toEqual(9); // 9 actions

--- a/__tests__/actions/swagger.ts
+++ b/__tests__/actions/swagger.ts
@@ -1,5 +1,8 @@
 import { Process, specHelper } from "./../../src/index";
+import { UnwrapPromise } from "../..";
+import { Swagger } from "../../src/actions/swagger";
 
+type ActionResponse = UnwrapPromise<typeof Swagger.prototype.run>;
 const actionhero = new Process();
 
 describe("Action", () => {
@@ -14,7 +17,11 @@ describe("Action", () => {
     });
 
     test("returns the correct parts", async () => {
-      const { paths, basePath, host } = await specHelper.runAction("swagger");
+      const {
+        paths,
+        basePath,
+        host,
+      }: ActionResponse = await specHelper.runAction("swagger");
       expect(basePath).toBe("/api/");
       expect(host).toMatch(/localhost/);
       expect(Object.keys(paths).length).toEqual(9); // 9 actions

--- a/__tests__/actions/validationTest.ts
+++ b/__tests__/actions/validationTest.ts
@@ -1,5 +1,8 @@
 import { Process, specHelper } from "./../../src/index";
+import { UnwrapPromise } from "../..";
+import { ValidationTest } from "../../src/actions/validationTest";
 
+type ActionResponse = UnwrapPromise<typeof ValidationTest.prototype.run>;
 const actionhero = new Process();
 
 describe("Action", () => {
@@ -26,6 +29,16 @@ describe("Action", () => {
       expect(error).toEqual(
         'Error: Input for parameter "string" failed validation!'
       );
+    });
+
+    test("works with a string", async () => {
+      const { string }: ActionResponse = await specHelper.runAction(
+        "validationTest",
+        {
+          string: "hello",
+        }
+      );
+      expect(string).toEqual("hello");
     });
   });
 });

--- a/__tests__/actions/validationTest.ts
+++ b/__tests__/actions/validationTest.ts
@@ -1,8 +1,7 @@
 import { Process, specHelper } from "./../../src/index";
-import { UnwrapPromise } from "../..";
 import { ValidationTest } from "../../src/actions/validationTest";
 
-type ActionResponse = UnwrapPromise<typeof ValidationTest.prototype.run>;
+const RunMethod = ValidationTest.prototype.run;
 const actionhero = new Process();
 
 describe("Action", () => {
@@ -32,10 +31,11 @@ describe("Action", () => {
     });
 
     test("works with a string", async () => {
-      const { string }: ActionResponse = await specHelper.runAction(
+      const { string } = await specHelper.runAction<typeof RunMethod>(
         "validationTest",
         {
           string: "hello",
+          ValidationTest,
         }
       );
       expect(string).toEqual("hello");

--- a/__tests__/tasks/runAction.ts
+++ b/__tests__/tasks/runAction.ts
@@ -1,5 +1,7 @@
 import { Process, specHelper } from "./../../src/index";
+import { RunAction } from "../../src/tasks/runAction";
 
+const RunMethod = RunAction.prototype.run;
 const actionhero = new Process();
 
 describe("Test: RunAction", () => {
@@ -12,25 +14,31 @@ describe("Test: RunAction", () => {
   });
 
   test("can run the task without params", async () => {
-    const { randomNumber } = await specHelper.runTask("runAction", {
-      action: "randomNumber",
-    });
+    const { randomNumber } = await specHelper.runTask<typeof RunMethod>(
+      "runAction",
+      {
+        action: "randomNumber",
+      }
+    );
     expect(randomNumber).toBeGreaterThanOrEqual(0);
     expect(randomNumber).toBeLessThan(1);
   });
 
   test("can run the task with params", async () => {
-    const { cacheTestResults } = await specHelper.runTask("runAction", {
-      action: "cacheTest",
-      params: { key: "testKey", value: "testValue" },
-    });
+    const { cacheTestResults } = await specHelper.runTask<typeof RunMethod>(
+      "runAction",
+      {
+        action: "cacheTest",
+        params: { key: "testKey", value: "testValue" },
+      }
+    );
     expect(cacheTestResults.saveResp).toBe(true);
     expect(cacheTestResults.deleteResp).toBe(true);
   });
 
   test("will throw with errors", async () => {
     await expect(
-      specHelper.runTask("runAction", {
+      specHelper.runTask<typeof RunMethod>("runAction", {
         action: "cacheTest",
       })
     ).rejects.toThrow(/key is a required parameter for this action/);

--- a/src/actions/status.ts
+++ b/src/actions/status.ts
@@ -13,7 +13,7 @@ const packageJSON = JSON.parse(
 // These values are probably good starting points, but you should expect to tweak them for your application
 const maxMemoryAlloted = process.env.maxMemoryAlloted || 500;
 const maxResqueQueueLength = process.env.maxResqueQueueLength || 1000;
-export default class Status extends Action {
+export class Status extends Action {
   constructor() {
     super();
     this.name = "status";

--- a/src/modules/specHelper.ts
+++ b/src/modules/specHelper.ts
@@ -1,6 +1,7 @@
 import * as uuid from "uuid";
 import { Worker } from "node-resque";
 import { api, config, task } from "./../index";
+import { UnwrapPromise } from "./tsUtils/unwrapPromise";
 
 export namespace specHelper {
   /**
@@ -13,10 +14,10 @@ export namespace specHelper {
   /**
    * Run an action via the specHelper server.
    */
-  export async function runAction(
+  export async function runAction<ActionRunMethod>(
     actionName: string,
     input: { [key: string]: any } = {}
-  ): Promise<any> {
+  ) {
     let connection;
 
     if (input.id && input.type === "testServer") {
@@ -29,7 +30,9 @@ export namespace specHelper {
     connection.params.action = actionName;
 
     connection.messageId = connection.params.messageId || uuid.v4();
-    const response = await new Promise((resolve) => {
+    const response: UnwrapPromise<ActionRunMethod> & {
+      error: string;
+    } = await new Promise((resolve) => {
       api.servers.servers.testServer.processAction(connection);
       connection.actionCallbacks[connection.messageId] = resolve;
     });

--- a/src/modules/specHelper.ts
+++ b/src/modules/specHelper.ts
@@ -60,22 +60,25 @@ export namespace specHelper {
    * Use the specHelper to run a task.
    * Note: this only runs the task's `run()` method, and no middleware.  This is faster than api.specHelper.runFullTask.
    */
-  export async function runTask(
+  export async function runTask<TaskRunMethod>(
     taskName: string,
     params: object | Array<any>
-  ): Promise<{ [key: string]: any }> {
+  ) {
     if (!api.tasks.tasks[taskName]) {
       throw new Error(`task ${taskName} not found`);
     }
 
-    return api.tasks.tasks[taskName].run(params);
+    const result: UnwrapPromise<TaskRunMethod> & {
+      error: string;
+    } = api.tasks.tasks[taskName].run(params);
+    return result;
   }
 
   /**
    * Use the specHelper to run a task.
    * Note: this will run a full Task worker, and will also include any middleware.  This is slower than api.specHelper.runTask.
    */
-  export async function runFullTask(
+  export async function runFullTask<TaskRunMethod>(
     taskName: string,
     params: object | Array<any>
   ) {
@@ -95,7 +98,9 @@ export namespace specHelper {
 
     try {
       await worker.connect();
-      const result = await worker.performInline(
+      const result: UnwrapPromise<TaskRunMethod> & {
+        error: string;
+      } = await worker.performInline(
         taskName,
         Array.isArray(params) ? params : [params]
       );

--- a/src/modules/specHelper.ts
+++ b/src/modules/specHelper.ts
@@ -16,7 +16,7 @@ export namespace specHelper {
   export async function runAction(
     actionName: string,
     input: { [key: string]: any } = {}
-  ): Promise<{ [key: string]: any }> {
+  ): Promise<any> {
     let connection;
 
     if (input.id && input.type === "testServer") {

--- a/src/modules/specHelper.ts
+++ b/src/modules/specHelper.ts
@@ -30,11 +30,11 @@ export namespace specHelper {
     connection.params.action = actionName;
 
     connection.messageId = connection.params.messageId || uuid.v4();
-    const response: ActionRunMethod extends Action["run"]
+    const response: (ActionRunMethod extends Action["run"]
       ? UnwrapPromise<ActionRunMethod>
-      : any & {
-          error: string;
-        } = await new Promise((resolve) => {
+      : any) & {
+      error: string;
+    } = await new Promise((resolve) => {
       api.servers.servers.testServer.processAction(connection);
       connection.actionCallbacks[connection.messageId] = resolve;
     });
@@ -70,11 +70,11 @@ export namespace specHelper {
       throw new Error(`task ${taskName} not found`);
     }
 
-    const result: TaskRunMethod extends Task["run"]
+    const result: (TaskRunMethod extends Task["run"]
       ? UnwrapPromise<TaskRunMethod>
-      : any & {
-          error: string;
-        } = api.tasks.tasks[taskName].run(params);
+      : any) & {
+      error: string;
+    } = api.tasks.tasks[taskName].run(params);
     return result;
   }
 
@@ -102,11 +102,11 @@ export namespace specHelper {
 
     try {
       await worker.connect();
-      const result: TaskRunMethod extends Task["run"]
+      const result: (TaskRunMethod extends Task["run"]
         ? UnwrapPromise<TaskRunMethod>
-        : any & {
-            error: string;
-          } = await worker.performInline(
+        : any) & {
+        error: string;
+      } = await worker.performInline(
         taskName,
         Array.isArray(params) ? params : [params]
       );


### PR DESCRIPTION
(Typescript) This PR updates the `specHelper` such that you can provide the Action or Task run method type to it so that the response type returned will defend by the Action.

```ts
import { Process, specHelper } from "actionhero";
import { RandomNumber } from "../../src/actions/randomNumber";

const RunMethod = RandomNumber.prototype.run;
const actionhero = new Process();

describe("Action", () => {
  describe("randomNumber", () => {
    beforeAll(async () => {
      await actionhero.start();
    });

    afterAll(async () => {
      await actionhero.stop();
    });

    test("generates random numbers", async () => {
      // Now, the response type of `specHelper.runAction` will be known ahead of time!
      const { randomNumber } = await specHelper.runAction<typeof RunMethod>(
        "randomNumber"
      );
      expect(randomNumber).toBeGreaterThan(0);
      expect(randomNumber).toBeLessThan(1);
    });
  });
});
```

<img width="572" alt="Screen Shot 2020-12-10 at 2 29 45 PM" src="https://user-images.githubusercontent.com/303226/101837772-683a1400-3af4-11eb-9191-5096f7cee177.png">

