### PR TITLE
Provide CLI option descriptions and show defaults

### DIFF
--- a/src/bin/methods/generate/action.ts
+++ b/src/bin/methods/generate/action.ts
@@ -10,8 +10,15 @@ export class GenerateAction extends CLI {
     this.example =
       "actionhero generate action --name=<name> --description=[description]";
     this.inputs = {
-      name: { required: true },
-      description: { required: true, default: "an actionhero action" },
+      name: {
+        required: true,
+        description: "The name of the Action to Generate",
+      },
+      description: {
+        required: true,
+        description: "The description of the Action",
+        default: "an actionhero action",
+      },
     };
   }
 

--- a/src/bin/methods/generate/cli.ts
+++ b/src/bin/methods/generate/cli.ts
@@ -9,9 +9,20 @@ export class GenerateCLI extends CLI {
     this.description = "Generate a new cli command";
     this.example = "actionhero generate cli --name=<name>";
     this.inputs = {
-      name: { required: true },
-      description: { required: false, default: "an actionhero cli command" },
-      example: { required: false, default: "actionhero command --option=yes" },
+      name: {
+        required: true,
+        description: "The name of the CLI Command to generate",
+      },
+      description: {
+        required: false,
+        description: "The name of the CLI Command",
+        default: "an actionhero cli command",
+      },
+      example: {
+        required: false,
+        description: "An example to include for the CLI Command's help",
+        default: "actionhero command --option=yes",
+      },
     };
   }
 

--- a/src/bin/methods/generate/initializer.ts
+++ b/src/bin/methods/generate/initializer.ts
@@ -10,10 +10,25 @@ export class GenerateInitializer extends CLI {
     this.example =
       "actionhero generate initializer --name=<name> --loadPriority=[p] --startPriority=[p] --stopPriority=[p]";
     this.inputs = {
-      name: { required: true },
-      loadPriority: { required: true, default: 1000 },
-      startPriority: { required: true, default: 1000 },
-      stopPriority: { required: true, default: 1000 },
+      name: {
+        required: true,
+        description: "The name of the Initializer to generate",
+      },
+      loadPriority: {
+        required: true,
+        description: "The order that this Initializer will initialize",
+        default: 1000,
+      },
+      startPriority: {
+        required: true,
+        description: "The order that this Initializer will start",
+        default: 1000,
+      },
+      stopPriority: {
+        required: true,
+        description: "The order that this Initializer will stop",
+        default: 1000,
+      },
     };
   }
 

--- a/src/bin/methods/generate/server.ts
+++ b/src/bin/methods/generate/server.ts
@@ -9,7 +9,10 @@ export class GenerateServer extends CLI {
     this.description = "Generate a new Server";
     this.example = "actionhero generate server --name=<name>";
     this.inputs = {
-      name: { required: true },
+      name: {
+        required: true,
+        description: "The name of the Server to generate",
+      },
     };
   }
 

--- a/src/bin/methods/generate/task.ts
+++ b/src/bin/methods/generate/task.ts
@@ -10,10 +10,21 @@ export class GenerateTask extends CLI {
     this.example =
       "actionhero generate task --name=<name> -queue=<queue> --description=[description] --frequency=[frequency]";
     this.inputs = {
-      name: { required: true },
-      queue: { required: true },
-      description: { required: true, default: "an actionhero task" },
-      frequency: { required: true, default: "0" },
+      name: { required: true, description: "The name of the Task to generate" },
+      queue: {
+        required: true,
+        description: "The queue that this Task will run on",
+      },
+      description: {
+        required: true,
+        description: "The description of this Task",
+        default: "an actionhero task",
+      },
+      frequency: {
+        required: true,
+        description: "Should this Task run periodically? Frequency is in ms",
+        default: "0",
+      },
     };
   }
 

--- a/src/bin/methods/task/enqueue.ts
+++ b/src/bin/methods/task/enqueue.ts
@@ -6,10 +6,13 @@ export class TaskEnqueue extends CLI {
     this.name = "task-enqueue";
     this.description = "Enqueue a defined Task into your actionhero cluster";
     this.example =
-      "actionhero task enqueue --name=[taskName] --args=[JSON-formatted args]";
+      "actionhero task enqueue --name=[taskName] --args=[JSON-encoded args]";
     this.inputs = {
-      name: { required: true },
-      args: { required: false },
+      name: { required: true, description: "The name of the Task to enqueue" },
+      args: {
+        required: false,
+        description: "Arguments to the Task (JSON encoded)",
+      },
     };
   }
 


### PR DESCRIPTION
In combination with #1679, the Actionhero CLI commands now come with descriptions! 

```
➜  actionhero generate-task --help
Usage: actionhero generate-task [options]

Generate a new Task

Options:
  --name <name>                The name of the Task to generate
  --queue <queue>              The queue that this Task will run on
  --description [description]  The description of this Task (default: "an actionhero task")
  --frequency [frequency]      Should this Task run periodically? Frequency is in ms (default: "0")
  -h, --help                   display help for command

Example:
  actionhero generate task --name=<name> -queue=<queue> --description=[description] --frequency=[frequency]
```