### PR TITLE
Type CLI input tpes and support both ARGS and OPTS

### DIFF
--- a/__tests__/core/plugins.ts
+++ b/__tests__/core/plugins.ts
@@ -86,7 +86,7 @@ describe("Core: Plugins", () => {
           { env }
         );
         expect(error2).toEqual("");
-        expect(helloResponse).toContain("hello");
+        expect(helloResponse).toContain("Hello, Actionhero");
       },
       30 * 1000
     );

--- a/__tests__/testPlugin/dist/bin/hello.js
+++ b/__tests__/testPlugin/dist/bin/hello.js
@@ -1,15 +1,24 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.Hello = void 0;
 const index_1 = require("../../../../src/index");
-class Version extends index_1.CLI {
+class Hello extends index_1.CLI {
     constructor() {
         super();
         this.name = "hello";
         this.description = "I say hello";
+        this.inputs = {
+            name: {
+                required: true,
+                description: 'Who we are greeting',
+                letter: 'g',
+                default: 'Actionhero'
+            }
+        };
     }
-    async run() {
-        console.log("hello");
+    async run({ params }) {
+        console.log(`Hello, ${params.name}`);
         return true;
     }
 }
-exports.Version = Version;
+exports.Hello = Hello;

--- a/__tests__/testPlugin/src/bin/hello.ts
+++ b/__tests__/testPlugin/src/bin/hello.ts
@@ -1,14 +1,22 @@
 import { CLI } from "../../../../src/index";
 
-export class Version extends CLI {
+export class Hello extends CLI {
   constructor() {
     super();
     this.name = "hello";
     this.description = "I say hello";
+    this.inputs={
+      name: {
+        required: true,
+        description: 'Who we are greeting',
+        letter: 'g',
+        default: 'Actionhero'
+    }
+    }
   }
 
-  async run() {
-    console.log("hello");
+  async run({params}) {
+    console.log(`Hello, ${params.name}`);
     return true;
   }
 }

--- a/__tests__/testPlugin/tsconfig.json
+++ b/__tests__/testPlugin/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "rootDir": ".",
     "outDir": "./dist",
     "allowJs": true,
     "module": "commonjs",

--- a/src/bin/methods/generate/initializer.ts
+++ b/src/bin/methods/generate/initializer.ts
@@ -17,17 +17,17 @@ export class GenerateInitializer extends CLI {
       loadPriority: {
         required: true,
         description: "The order that this Initializer will initialize",
-        default: 1000,
+        default: "1000",
       },
       startPriority: {
         required: true,
         description: "The order that this Initializer will start",
-        default: 1000,
+        default: "1000",
       },
       stopPriority: {
         required: true,
         description: "The order that this Initializer will stop",
-        default: 1000,
+        default: "1000",
       },
     };
   }

--- a/src/classes/cli.ts
+++ b/src/classes/cli.ts
@@ -1,7 +1,7 @@
 /**
- * Create a new Actionhero CLI Command. The required properties of an CLI command. These can be defined statically (this.name) or as methods which return a value.
+ * An Actionhero CLI Command.
+ * For inputs, you can provide Options (--thing=stuff) with the "Inputs" object, or define Arguments in the name of the command (`greet [name]`)
  */
-
 export abstract class CLI {
   /**The name of the CLI command. */
   name: string;
@@ -11,7 +11,13 @@ export abstract class CLI {
   example: string;
   /**The inputs of the CLI command (default: {}) */
   inputs: {
-    [key: string]: any;
+    [key: string]: {
+      required?: boolean;
+      default?: string | boolean;
+      letter?: string;
+      flag?: boolean;
+      description?: string;
+    };
   };
 
   /** Should the server initialize before running this command? */
@@ -38,6 +44,11 @@ export abstract class CLI {
    */
 
   abstract run(data: { [key: string]: any }): Promise<boolean>;
+
+  /**
+   * An optional method to append additional information to the --help response for this CLI command
+   */
+  help() {}
 
   private getDefaults() {
     return {


### PR DESCRIPTION
Type the inputs of CLI commands.  Yo can now define CLI commands which accept both ARGS and OPTS.  Consider the following:

1. `actionhero hello evan` would be `hello <name>`, where is a **required argument**.
2. `actionhero hello --name evan` would be the `hello` command, with an option of `name`. 

Here's what both of those look like:

```ts
import {CLI} from 'actionhero'

export class HelloArguments extends CLI {
  constructor() {
    super();
    this.name = "hello <name>";
    this.description = "I say hello";
    this.example = "actionhero hello evan"
    }
  }

  async run({params}) {
    console.log(`Hello, ${params._arguments[0]}`);
    return true;
  }
}

export class HelloOptions extends CLI {
  constructor() {
    super();
    this.name = "hello";
    this.description = "I say hello";
    this.example = "actionhero hello --name evan"
    this.inputs={
      name: {
        required: true,
        description: 'Who we are greeting',
        letter: 'n',
        default: 'Actionhero'
    }
    }
  }

  async run({params}) {
    console.log(`Hello, ${params.name}`);
    return true;
  }
}


```
