### PR TITLE
use `ACTIONHERO_FATAL_ERROR_STACK_DISPLAY` to toggle showing the error stack or just message

### DIFF
--- a/src/classes/process.ts
+++ b/src/classes/process.ts
@@ -407,7 +407,7 @@ export class Process {
         ? process.env.ACTIONHERO_FATAL_ERROR_STACK_DISPLAY === "true"
         : true;
       errors.forEach((error) => {
-        log(showStack ? error.stack || error : error.message || error, "debug");
+        log(showStack ? error.stack ?? error : error.message ?? error, "emerg");
       });
 
       await this.stop();

--- a/src/classes/process.ts
+++ b/src/classes/process.ts
@@ -404,7 +404,10 @@ export class Process {
       log(`Error with initializer step: ${JSON.stringify(type)}`, "emerg");
 
       errors.forEach((error) => {
-        log(error.stack, "emerg");
+        log(
+          error.stack,
+          process.env.ACTIONHERO_FATAL_ERROR_STACK_LOG_LEVEL || "emerg"
+        );
       });
 
       await this.stop();

--- a/src/classes/process.ts
+++ b/src/classes/process.ts
@@ -403,11 +403,11 @@ export class Process {
     if (errors) {
       log(`Error with initializer step: ${JSON.stringify(type)}`, "emerg");
 
+      const showStack = process.env.ACTIONHERO_FATAL_ERROR_STACK_DISPLAY
+        ? process.env.ACTIONHERO_FATAL_ERROR_STACK_DISPLAY === "true"
+        : true;
       errors.forEach((error) => {
-        log(
-          error.stack,
-          process.env.ACTIONHERO_FATAL_ERROR_STACK_LOG_LEVEL || "emerg"
-        );
+        log(showStack ? error.stack || error : error.message || error, "debug");
       });
 
       await this.stop();


### PR DESCRIPTION
default behavior

```
npm run dev

> actionhero@25.0.10 dev
> ts-node-dev --transpile-only --no-deps ./src/server

[INFO] 17:58:04 ts-node-dev ver. 1.1.6 (using ts-node ver. 9.1.1, typescript ver. 4.2.4)
2021-04-22T00:58:05.746Z - emerg: Exception occurred in initializer `actions` during load
2021-04-22T00:58:05.747Z - emerg: Error with initializer step: "initialize"
2021-04-22T00:58:05.756Z - emerg: Error: Oh No!
    at Object.index_1.api.actions.loadFile (/Users/evan/workspace/actionhero/actionhero/src/initializers/actions.ts:55:13)
    at Actions.initialize (/Users/evan/workspace/actionhero/actionhero/src/initializers/actions.ts:102:27)
    at Object.initializeFunction (/Users/evan/workspace/actionhero/actionhero/src/classes/process.ts:159:33)
    at Object.asyncWaterfall (/Users/evan/workspace/actionhero/actionhero/src/modules/utils/asyncWaterfall.ts:46:29)
    at processTicksAndRejections (node:internal/process/task_queues:94:5)
    at Process.initialize (/Users/evan/workspace/actionhero/actionhero/src/classes/process.ts:249:7)
    at Process.start (/Users/evan/workspace/actionhero/actionhero/src/classes/process.ts:258:36)
    at main (/Users/evan/workspace/actionhero/actionhero/src/server.ts:17:3)
2021-04-22T00:58:05.756Z - crit: Cannot shut down actionhero, not running
```

just error messages:
```
ACTIONHERO_FATAL_ERROR_STACK_DISPLAY=false npm run dev

> actionhero@25.0.10 dev
> ts-node-dev --transpile-only --no-deps ./src/server

[INFO] 17:58:18 ts-node-dev ver. 1.1.6 (using ts-node ver. 9.1.1, typescript ver. 4.2.4)
2021-04-22T00:58:19.412Z - emerg: Exception occurred in initializer `actions` during load
2021-04-22T00:58:19.412Z - emerg: Error with initializer step: "initialize"
2021-04-22T00:58:19.412Z - emerg: Oh No!
2021-04-22T00:58:19.412Z - crit: Cannot shut down actionhero, not running
```