### PR TITLE
[cli] add support for custom placeholder and variadic options

### DIFF
--- a/src/bin/actionhero.ts
+++ b/src/bin/actionhero.ts
@@ -107,7 +107,11 @@ export namespace ActionheroCLIRunner {
       const methodName = input.required ? "requiredOption" : "option";
       command[methodName](
         `${input.letter ? `-${input.letter}, ` : ""}--${key} ${
-          input.flag ? "" : `${separators[0]}${key}${separators[1]}`
+          input.flag
+            ? ""
+            : `${separators[0]}${input.placeholder || key}${
+                input.variadic ? "..." : ""
+              }${separators[1]}`
         }`,
         input.description,
         input.default

--- a/src/classes/cli.ts
+++ b/src/classes/cli.ts
@@ -16,6 +16,8 @@ export abstract class CLI {
       default?: string | boolean;
       letter?: string;
       flag?: boolean;
+      placeholder?: string;
+      variadic?: boolean;
       description?: string;
     };
   };


### PR DESCRIPTION
When defining a CLI command, I wanted to be able to use a [Variadic option](https://github.com/tj/commander.js/#variadic-option), but did not find a way to do this through actionhero. Commander supports this by adding `...` to the placeholder so you'll get back an array of all the options the user specified when running the command.

This also adds the ability to customize the value placeholder to pluralize it in the help section or use a different word entirely.

Currently this is possible by adding the ellipsis to the key, but it has some consequences on the usage of the param later on.