### PR TITLE
Update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/ioredis": "^4.22.2",
+        "@types/ioredis": "^4.26.0",
         "browser_fingerprint": "^2.0.3",
         "commander": "^7.2.0",
         "dot-prop": "^6.0.1",
@@ -17,26 +17,26 @@
         "formidable": "^1.2.2",
         "glob": "^7.1.6",
         "i18n": "^0.13.2",
-        "ioredis": "^4.24.6",
-        "ioredis-mock": "^5.4.1",
+        "ioredis": "^4.27.1",
+        "ioredis-mock": "^5.5.4",
         "is-running": "^2.1.0",
         "mime": "^2.5.2",
-        "node-resque": "^8.2.5",
+        "node-resque": "^8.2.7",
         "optimist": "^0.6.1",
         "primus": "^8.0.2",
         "qs": "^6.10.1",
-        "uglify-js": "^3.13.3",
+        "uglify-js": "^3.13.4",
         "uuid": "^8.3.2",
         "winston": "^3.3.3",
-        "ws": "^7.4.4"
+        "ws": "^7.4.5"
       },
       "bin": {
         "actionhero": "dist/bin/actionhero.js"
       },
       "devDependencies": {
         "@types/glob": "^7.1.3",
-        "@types/jest": "^26.0.22",
-        "@types/node": "^14.14.37",
+        "@types/jest": "^26.0.23",
+        "@types/node": "^14.14.41",
         "@types/puppeteer": "^5.4.3",
         "@types/uuid": "^8.3.0",
         "jest": "^26.6.3",
@@ -44,10 +44,10 @@
         "puppeteer": "^9.0.0",
         "request": "^2.88.2",
         "request-promise-native": "^1.0.9",
-        "ts-jest": "^26.5.4",
+        "ts-jest": "^26.5.5",
         "ts-node-dev": "^1.1.6",
-        "typedoc": "^0.20.34",
-        "typescript": "^4.2.3"
+        "typedoc": "^0.20.36",
+        "typescript": "^4.2.4"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -1349,9 +1349,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "26.0.22",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.22.tgz",
-      "integrity": "sha512-eeWwWjlqxvBxc4oQdkueW5OF/gtfSceKk4OnOAGlUSwS/liBRtZppbJuz1YkgbrbfGOoeBHun9fOvXnjNwrSOw==",
+      "version": "26.0.23",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.23.tgz",
+      "integrity": "sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==",
       "dev": true,
       "dependencies": {
         "jest-diff": "^26.0.0",
@@ -3765,21 +3765,22 @@
       }
     },
     "node_modules/ioredis-mock": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ioredis-mock/-/ioredis-mock-5.5.2.tgz",
-      "integrity": "sha512-hGbXu+5agBbJ7RJQS6aGCiooKqMdJc5p4EbN5lSRUlOfeo8nFn5gfH8bKHWEobOjTLVWeUbDiEAEBQ5N0g9CnQ==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/ioredis-mock/-/ioredis-mock-5.5.4.tgz",
+      "integrity": "sha512-u8AT/Y0RrlRSJKvd2zoJPdU6svA3kkMS3sRwakjdEahZgOiDo/yZ8urM91citQDNkcgbOXnSUwK9JBu3vtzOCg==",
       "dependencies": {
         "fengari": "^0.1.4",
         "fengari-interop": "^0.1.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "minimatch": "^3.0.4",
-        "standard-as-callback": "^2.0.1"
+        "standard-as-callback": "^2.1.0"
       },
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "ioredis": "4.x"
+        "ioredis": "4.x",
+        "redis-commands": "1.x"
       }
     },
     "node_modules/ip-regex": {
@@ -6358,11 +6359,11 @@
       }
     },
     "node_modules/node-resque": {
-      "version": "8.2.6",
-      "resolved": "https://registry.npmjs.org/node-resque/-/node-resque-8.2.6.tgz",
-      "integrity": "sha512-V6XTCVofHSLJS8gQzWH8pdYflInuQDpyFwzca2E/mSBTA1mKT9qc2HH9cVgdR/FYkZf5sHTKnhLwsl0bXNGcag==",
+      "version": "8.2.7",
+      "resolved": "https://registry.npmjs.org/node-resque/-/node-resque-8.2.7.tgz",
+      "integrity": "sha512-fG8QIRLl7OyZJ6126fm7P3h7kzWjMbhH4wOaAASFN1UHRmAXk9idXYDwEB1vcyV9KVZstZR53n3dH6zO/isxCA==",
       "dependencies": {
-        "ioredis": "^4.24.6"
+        "ioredis": "^4.27.1"
       },
       "engines": {
         "node": ">= 8"
@@ -10267,9 +10268,9 @@
       }
     },
     "@types/jest": {
-      "version": "26.0.22",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.22.tgz",
-      "integrity": "sha512-eeWwWjlqxvBxc4oQdkueW5OF/gtfSceKk4OnOAGlUSwS/liBRtZppbJuz1YkgbrbfGOoeBHun9fOvXnjNwrSOw==",
+      "version": "26.0.23",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.23.tgz",
+      "integrity": "sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==",
       "dev": true,
       "requires": {
         "jest-diff": "^26.0.0",
@@ -12255,15 +12256,15 @@
       }
     },
     "ioredis-mock": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ioredis-mock/-/ioredis-mock-5.5.2.tgz",
-      "integrity": "sha512-hGbXu+5agBbJ7RJQS6aGCiooKqMdJc5p4EbN5lSRUlOfeo8nFn5gfH8bKHWEobOjTLVWeUbDiEAEBQ5N0g9CnQ==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/ioredis-mock/-/ioredis-mock-5.5.4.tgz",
+      "integrity": "sha512-u8AT/Y0RrlRSJKvd2zoJPdU6svA3kkMS3sRwakjdEahZgOiDo/yZ8urM91citQDNkcgbOXnSUwK9JBu3vtzOCg==",
       "requires": {
         "fengari": "^0.1.4",
         "fengari-interop": "^0.1.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "minimatch": "^3.0.4",
-        "standard-as-callback": "^2.0.1"
+        "standard-as-callback": "^2.1.0"
       }
     },
     "ip-regex": {
@@ -14389,11 +14390,11 @@
       }
     },
     "node-resque": {
-      "version": "8.2.6",
-      "resolved": "https://registry.npmjs.org/node-resque/-/node-resque-8.2.6.tgz",
-      "integrity": "sha512-V6XTCVofHSLJS8gQzWH8pdYflInuQDpyFwzca2E/mSBTA1mKT9qc2HH9cVgdR/FYkZf5sHTKnhLwsl0bXNGcag==",
+      "version": "8.2.7",
+      "resolved": "https://registry.npmjs.org/node-resque/-/node-resque-8.2.7.tgz",
+      "integrity": "sha512-fG8QIRLl7OyZJ6126fm7P3h7kzWjMbhH4wOaAASFN1UHRmAXk9idXYDwEB1vcyV9KVZstZR53n3dH6zO/isxCA==",
       "requires": {
-        "ioredis": "^4.24.6"
+        "ioredis": "^4.27.1"
       }
     },
     "normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "node": ">=8.0.0"
   },
   "dependencies": {
-    "@types/ioredis": "^4.22.2",
+    "@types/ioredis": "^4.26.0",
     "browser_fingerprint": "^2.0.3",
     "commander": "^7.2.0",
     "dot-prop": "^6.0.1",
@@ -42,23 +42,23 @@
     "formidable": "^1.2.2",
     "glob": "^7.1.6",
     "i18n": "^0.13.2",
-    "ioredis": "^4.24.6",
-    "ioredis-mock": "^5.4.1",
+    "ioredis": "^4.27.1",
+    "ioredis-mock": "^5.5.4",
     "is-running": "^2.1.0",
     "mime": "^2.5.2",
-    "node-resque": "^8.2.5",
+    "node-resque": "^8.2.7",
     "optimist": "^0.6.1",
     "primus": "^8.0.2",
     "qs": "^6.10.1",
-    "uglify-js": "^3.13.3",
+    "uglify-js": "^3.13.4",
     "uuid": "^8.3.2",
     "winston": "^3.3.3",
-    "ws": "^7.4.4"
+    "ws": "^7.4.5"
   },
   "devDependencies": {
     "@types/glob": "^7.1.3",
-    "@types/jest": "^26.0.22",
-    "@types/node": "^14.14.37",
+    "@types/jest": "^26.0.23",
+    "@types/node": "^14.14.41",
     "@types/puppeteer": "^5.4.3",
     "@types/uuid": "^8.3.0",
     "jest": "^26.6.3",
@@ -66,10 +66,10 @@
     "puppeteer": "^9.0.0",
     "request": "^2.88.2",
     "request-promise-native": "^1.0.9",
-    "ts-jest": "^26.5.4",
+    "ts-jest": "^26.5.5",
     "ts-node-dev": "^1.1.6",
-    "typedoc": "^0.20.34",
-    "typescript": "^4.2.3"
+    "typedoc": "^0.20.36",
+    "typescript": "^4.2.4"
   },
   "optionalDependencies": {},
   "bin": {


### PR DESCRIPTION
Specifically, this PR updates `node-resque`, which handled some breaking changes in the latest version of `ioredis-mock` (https://github.com/actionhero/node-resque/pull/576)