### PR TITLE
Store the reason that `process.stop()` was called

### DIFF
--- a/__tests__/core/process.ts
+++ b/__tests__/core/process.ts
@@ -25,7 +25,8 @@ describe("Core", () => {
     });
 
     test("a new process can be stopped", async () => {
-      await actionhero.stop();
+      await actionhero.stop("some reason");
+      expect(actionhero.stopReasons).toEqual(["some reason"]);
       expect(actionhero.initialized).toBe(false);
       expect(actionhero.started).toBe(false);
       expect(actionhero.stopped).toBe(true);

--- a/src/classes/process.ts
+++ b/src/classes/process.ts
@@ -20,7 +20,7 @@ export class Process {
   initialized: boolean;
   started: boolean;
   stopped: boolean;
-  stopReasons?: string[] = [];
+  stopReasons?: string[];
   shuttingDown: boolean;
   bootTime: number;
   initializers: Initializers;
@@ -40,6 +40,7 @@ export class Process {
     this.loadInitializers = [];
     this.startInitializers = [];
     this.stopInitializers = [];
+    this.stopReasons = [];
 
     this.startCount = 0;
 

--- a/src/classes/process.ts
+++ b/src/classes/process.ts
@@ -20,7 +20,7 @@ export class Process {
   initialized: boolean;
   started: boolean;
   stopped: boolean;
-  stopReasons?: string[];
+  stopReasons?: string[] = [];
   shuttingDown: boolean;
   bootTime: number;
   initializers: Initializers;
@@ -297,7 +297,7 @@ export class Process {
         : undefined;
 
       log("stopping process...", "notice");
-      if (this.stopReasons.length > 0) {
+      if (this.stopReasons?.length > 0) {
         log(`stop reasons: ${this.stopReasons.join(", ")}`, "debug");
       }
 

--- a/src/classes/process.ts
+++ b/src/classes/process.ts
@@ -285,17 +285,15 @@ export class Process {
     this.started = true;
   }
 
-  async stop(stopReasons?: string | string[]) {
+  async stop(stopReasons: string | string[] = []) {
     if (this.running) {
       this.shuttingDown = true;
       this.running = false;
       this.initialized = false;
       this.started = false;
-      this.stopReasons = stopReasons
-        ? Array.isArray(stopReasons)
-          ? stopReasons
-          : [stopReasons]
-        : undefined;
+      this.stopReasons = Array.isArray(stopReasons)
+        ? stopReasons
+        : [stopReasons];
 
       log("stopping process...", "notice");
       if (this.stopReasons?.length > 0) {

--- a/src/classes/process.ts
+++ b/src/classes/process.ts
@@ -20,6 +20,7 @@ export class Process {
   initialized: boolean;
   started: boolean;
   stopped: boolean;
+  stopReasons?: string[];
   shuttingDown: boolean;
   bootTime: number;
   initializers: Initializers;
@@ -283,14 +284,23 @@ export class Process {
     this.started = true;
   }
 
-  async stop() {
+  async stop(stopReasons?: string | string[]) {
     if (this.running) {
       this.shuttingDown = true;
       this.running = false;
       this.initialized = false;
       this.started = false;
+      this.stopReasons = stopReasons
+        ? Array.isArray(stopReasons)
+          ? stopReasons
+          : [stopReasons]
+        : undefined;
 
       log("stopping process...", "notice");
+      if (this.stopReasons.length > 0) {
+        log(`stop reasons: ${this.stopReasons.join(", ")}`, "debug");
+      }
+
       await utils.sleep(100);
 
       this.stopInitializers.push(async () => {
@@ -396,10 +406,9 @@ export class Process {
   }
 
   // HELPERS
-  async fatalError(errors, type) {
-    if (errors && !(errors instanceof Array)) {
-      errors = [errors];
-    }
+  async fatalError(errors: Error | Error[] = [], type: any) {
+    if (!(errors instanceof Array)) errors = [errors];
+
     if (errors) {
       log(`Error with initializer step: ${JSON.stringify(type)}`, "emerg");
 
@@ -407,10 +416,15 @@ export class Process {
         ? process.env.ACTIONHERO_FATAL_ERROR_STACK_DISPLAY === "true"
         : true;
       errors.forEach((error) => {
-        log(showStack ? error.stack ?? error : error.message ?? error, "emerg");
+        log(
+          showStack
+            ? error.stack ?? error.toString()
+            : error.message ?? error.toString(),
+          "emerg"
+        );
       });
 
-      await this.stop();
+      await this.stop(errors.map((e) => e.message ?? e.toString()));
 
       await utils.sleep(1000); // allow time for console.log to print
       process.exit(1);


### PR DESCRIPTION
This PR allows `process.stop()` to be called with a "reason" or "reasons", eg `process.stop('something bad happened')`.  In this way, in the `stop()` methods of your initializers, you can inspect `process.stopReasons` to report errors, etc.

As part of this, if there's an error with an initializer,  the error thrown will end up as a `process.stopReasons`