### PR TITLE
Support SSL redis connections

### DIFF
--- a/src/config/redis.ts
+++ b/src/config/redis.ts
@@ -9,6 +9,7 @@ export const DEFAULT = {
   redis: (config) => {
     const konstructor = require("ioredis");
 
+    let protocol = "redis";
     let host = process.env.REDIS_HOST || "127.0.0.1";
     let port = process.env.REDIS_PORT || 6379;
     let db = process.env.REDIS_DB || process.env.JEST_WORKER_ID || "0";
@@ -16,6 +17,7 @@ export const DEFAULT = {
 
     if (process.env.REDIS_URL) {
       const parsed = new URL(process.env.REDIS_URL);
+      if (parsed.protocol) protocol = parsed.protocol.split(":")[0];
       if (parsed.password) password = parsed.password;
       if (parsed.hostname) host = parsed.hostname;
       if (parsed.port) port = parsed.port;
@@ -28,6 +30,7 @@ export const DEFAULT = {
       host,
       password,
       db: parseInt(db),
+      tls: protocol === "rediss" ? { rejectUnauthorized: false } : undefined,
       // you can learn more about retryStrategy @ https://github.com/luin/ioredis#auto-reconnect
       retryStrategy: (times) => {
         if (times === 1) {


### PR DESCRIPTION
This PR adds support for detecting a `rediss://`URL (Redis + TLS) and ignoring self-signed certificate warnings as a default configuration.  