### PR TITLE
Support Redis over SSL with Environment Variable

### DIFF
--- a/src/config/redis.ts
+++ b/src/config/redis.ts
@@ -8,8 +8,7 @@ import { URL } from "url";
 export const DEFAULT = {
   redis: (config) => {
     const konstructor = require("ioredis");
-
-    let protocol = "redis";
+    let protocol = process.env.REDIS_SSL ? "rediss" : "redis";
     let host = process.env.REDIS_HOST || "127.0.0.1";
     let port = process.env.REDIS_PORT || 6379;
     let db = process.env.REDIS_DB || process.env.JEST_WORKER_ID || "0";
@@ -30,6 +29,7 @@ export const DEFAULT = {
       host,
       password,
       db: parseInt(db),
+      // ssl options
       tls: protocol === "rediss" ? { rejectUnauthorized: false } : undefined,
       // you can learn more about retryStrategy @ https://github.com/luin/ioredis#auto-reconnect
       retryStrategy: (times) => {


### PR DESCRIPTION
Closes https://github.com/actionhero/actionhero/issues/1786

This PR configures `config/redis` to create an SSL connection if:
1) `process.env.REDIS_SSL=true`
2) The `REDIS_URL` starts with `rediss://`. This is the pattern that Heroku has popularized. 

The extra `s` is for secure!

> As of Redis version 6, Hobby plans support both TLS and unencrypted connections, while production plans require TLS connections. For hobby plans you can find the unencrypted (plaintext) and TLS URIs in your app’s config vars REDIS_URL and REDIS_TLS_URL respectively. For Premium, Private, and Shield plans on version 6 your REDIS_URL config var will use the rediss: scheme, and you must enable TLS in your Redis client’s configuration in order to connect to a Redis 6 database.

https://devcenter.heroku.com/articles/heroku-redis

---

Thanks, https://github.com/grouparoo/grouparoo/pull/1729