### PR TITLE
`config.general.filteredParams` and `config.general.filteredResponse` can be a function

### DIFF
--- a/__tests__/integration/browser.ts
+++ b/__tests__/integration/browser.ts
@@ -68,8 +68,8 @@ describe("browser integration tests", () => {
 
     test("documentation is loaded", async () => {
       await page.goto(url);
-      await page.waitForSelector("h4");
-      const actionNames = await page.$$eval("h4", (elements) =>
+      await page.waitForSelector("h3");
+      const actionNames = await page.$$eval("h3", (elements) =>
         elements.map((e) => e.textContent)
       );
       expect(actionNames.sort()).toEqual([

--- a/__tests__/utils/utils.ts
+++ b/__tests__/utils/utils.ts
@@ -269,7 +269,7 @@ describe("Utils", () => {
 
     afterEach(() => {
       // after each test, empty the array
-      config.general.filteredParams.length = 0;
+      config.general.filteredParams = [];
     });
 
     const testInput = {
@@ -334,6 +334,19 @@ describe("Utils", () => {
       expect(filteredParams.o1.o1p1).toEqual(testInput.o1.o1p1);
       expect(filteredParams.o1.o2.o2p2).toEqual(testInput.o1.o2.o2p2);
     });
+
+    test("can filter with a function rather than an array", () => {
+      const inputs = JSON.parse(JSON.stringify(testInput)); // quick deep Clone
+      config.general.filteredParams = () => {
+        return ["p1", "p2", "o2"];
+      };
+
+      const filteredParams = utils.filterObjectForLogging(inputs);
+      expect(filteredParams.p1).toEqual("[FILTERED]");
+      expect(filteredParams.p2).toEqual("[FILTERED]");
+      expect(filteredParams.o2).toEqual("[FILTERED]"); // entire object filtered
+      expect(filteredParams.o1).toEqual(testInput.o1); // unchanged
+    });
   });
 
   describe("utils.filterResponseForLogging", () => {
@@ -343,7 +356,7 @@ describe("Utils", () => {
 
     afterEach(() => {
       // after each test, empty the array
-      config.general.filteredResponse.length = 0;
+      config.general.filteredResponse = [];
     });
 
     const testInput = {
@@ -415,6 +428,19 @@ describe("Utils", () => {
       expect(filteredRespnose.p1).toEqual(testInput.p1);
       expect(filteredRespnose.o1.o1p1).toEqual(testInput.o1.o1p1);
       expect(filteredRespnose.o1.o2.o2p2).toEqual(testInput.o1.o2.o2p2);
+    });
+
+    test("can filter with a function rather than an array", () => {
+      const inputs = JSON.parse(JSON.stringify(testInput)); // quick deep Clone
+      config.general.filteredResponse = () => {
+        return ["p1", "p2", "o2"];
+      };
+
+      const filteredRespnose = utils.filterResponseForLogging(inputs);
+      expect(filteredRespnose.p1).toEqual("[FILTERED]");
+      expect(filteredRespnose.p2).toEqual("[FILTERED]");
+      expect(filteredRespnose.o2).toEqual("[FILTERED]"); // entire object filtered
+      expect(filteredRespnose.o1).toEqual(testInput.o1); // unchanged
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "typedoc": "^0.20.36",
     "typescript": "^4.2.4"
   },
-  "optionalDependencies": {},
   "bin": {
     "actionhero": "dist/bin/actionhero.js"
   },
@@ -86,7 +85,7 @@
   },
   "scripts": {
     "postinstall": "echo 'To generate a new actionhero project, run \"npx actionhero generate\"'",
-    "test": "jest --maxWorkers 5",
+    "test": "jest --maxWorkers 50%",
     "prepare": "npm run build && npm run docs",
     "pretest": "npm run lint && npm run build",
     "dev": "ts-node-dev --transpile-only --no-deps ./src/server",

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -28,9 +28,9 @@ export const DEFAULT = {
       disableParamScrubbing: false,
       // enable action response to logger
       enableResponseLogging: false,
-      // params you would like hidden from any logs
+      // params you would like hidden from any logs. Can be an array of strings or a method that returns an array of strings.
       filteredParams: [],
-      // responses you would like hidden from any logs
+      // responses you would like hidden from any logs. Can be an array of strings or a method that returns an array of strings.
       filteredResponse: [],
       // values that signify missing params
       missingParamChecks: [null, "", undefined],

--- a/src/initializers/resque.ts
+++ b/src/initializers/resque.ts
@@ -1,5 +1,5 @@
 import { Queue, Scheduler, MultiWorker, JobEmit } from "node-resque";
-import { api, log, config, Initializer } from "../index";
+import { api, log, utils, Initializer } from "../index";
 
 export interface ResqueApi {
   connectionDetails: {
@@ -29,17 +29,6 @@ export class Resque extends Initializer {
     this.loadPriority = 600;
     this.startPriority = 950;
     this.stopPriority = 100;
-  }
-
-  filterTaskParams(params: { [key: string]: any }) {
-    const filteredParams = Object.assign({}, params);
-    for (const key in params) {
-      if (config.general.filteredParams.indexOf(key) >= 0) {
-        filteredParams[key] = "[FILTERED]";
-      }
-    }
-
-    return filteredParams;
   }
 
   async initialize(config) {
@@ -189,7 +178,7 @@ export class Resque extends Initializer {
             workerId,
             class: job.class,
             queue: job.queue,
-            args: JSON.stringify(this.filterTaskParams(job.args[0])),
+            args: JSON.stringify(utils.filterObjectForLogging(job.args[0])),
           });
         });
         api.resque.multiWorker.on(
@@ -230,7 +219,7 @@ export class Resque extends Initializer {
               workerId,
               class: job.class,
               queue: job.queue,
-              args: JSON.stringify(this.filterTaskParams(job.args[0])),
+              args: JSON.stringify(utils.filterObjectForLogging(job.args[0])),
               result,
               duration,
             };


### PR DESCRIPTION
This PR allows `config.general.filteredParams` and `config.general.filteredResponse` to both be functions returning `string[]` in addition `string[]` directly.  In this way you can dynamically look up params you need to filter.