### PR TITLE
Update Log messages

### DIFF
--- a/src/classes/process.ts
+++ b/src/classes/process.ts
@@ -263,16 +263,16 @@ export class Process {
     this.running = true;
     api.running = true;
     log(`environment: ${env}`, "notice");
-    log("*** Starting Actionhero ***", "info");
+    log(`*** Starting ${config.general.serverName} ***`, "info");
 
     this.startInitializers.push(() => {
       this.bootTime = new Date().getTime();
       if (this.startCount === 0) {
         log(`server ID: ${id}`, "notice");
-        log("*** Actionhero Started ***", "notice");
+        log(`*** ${config.general.serverName} Started ***`, "notice");
         this.startCount++;
       } else {
-        log("*** Actionhero Restarted ***", "notice");
+        log(`*** ${config.general.serverName} Restarted ***`, "notice");
       }
     });
 
@@ -304,7 +304,7 @@ export class Process {
 
       this.stopInitializers.push(async () => {
         clearPidFile();
-        log("*** Actionhero Stopped ***", "notice");
+        log(`*** ${config.general.serverName} Stopped ***`, "notice");
         delete this.shuttingDown;
         // reset initializers to prevent duplicate check on restart
         this.initializers = {};
@@ -322,7 +322,7 @@ export class Process {
     } else if (this.shuttingDown === true) {
       // double sigterm; ignore it
     } else {
-      const message = "Cannot shut down actionhero, not running";
+      const message = `Cannot shut down ${config.general.serverName}, not running`;
       log(message, "crit");
     }
   }

--- a/src/initializers/servers.ts
+++ b/src/initializers/servers.ts
@@ -101,14 +101,17 @@ export class Servers extends Initializer {
       const serverName = serverNames[i];
       const server = api.servers.servers[serverName];
       if (server && server.config.enabled === true) {
-        let message = "";
-        message += `Starting server: \`${serverName}\``;
-        if (config.servers[serverName].bindIP) {
-          message += ` @ ${config.servers[serverName].bindIP}`;
-        }
-        if (config.servers[serverName].port) {
-          message += `:${config.servers[serverName].port}`;
-        }
+        const message = `Starting server: \`${serverName}\` ${
+          config.servers[serverName].bindIP
+            ? `@ ${serverName === "web" ? "http://" : ""}${
+                config.servers[serverName].bindIP
+              }${
+                config.servers[serverName].port
+                  ? `:${config.servers[serverName].port}`
+                  : ""
+              }`
+            : ""
+        }`;
         log(message, "notice");
         await server.start();
         log(`Server started: ${serverName}`, "debug");


### PR DESCRIPTION
Uses `${config.general.serverName}`, which in turn comes from `name` in `package.json` in the starting and stopping log messages:

```bash
# OLD
2021-05-19T22:17:54.491Z - info: *** Starting Actionhero ***
2021-05-19T22:17:54.925Z - notice: *** Actionhero Started ***
2021-05-19T22:20:03.470Z - notice: *** Actionhero Stopped ***

# NEW: 
2021-05-19T22:17:54.491Z - info: *** Starting MyApp ***
2021-05-19T22:17:54.925Z - notice: *** MyApp Started ***
2021-05-19T22:20:03.470Z - notice: *** MyApp Stopped ***
```


Also adds an `http://` in front of the web server start message to make it clickable in some terminals (eg: iterm, vscode).