### PR TITLE
Limit the number of array elements to log

### DIFF
--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -23,6 +23,7 @@ export const DEFAULT = {
     return {
       loggers,
       maxLogStringLength: 100, // the maximum length of param to log (we will truncate)
+      maxLogArrayLength: 10, // the maximum number of items in an array to log before collapsing into one message
     };
   },
 };

--- a/src/modules/utils/filterObjectForLogging.ts
+++ b/src/modules/utils/filterObjectForLogging.ts
@@ -8,6 +8,7 @@ import * as dotProp from "dot-prop";
  * Truncates long strings via `api.config.logger.maxLogStringLength`
  */
 export function filterObjectForLogging(params: object): { [key: string]: any } {
+  params = Object.assign({}, params);
   const sanitizedParams = {};
 
   for (const i in params) {
@@ -19,7 +20,7 @@ export function filterObjectForLogging(params: object): { [key: string]: any } {
     }
 
     if (isPlainObject(params[i])) {
-      sanitizedParams[i] = Object.assign({}, params[i]);
+      sanitizedParams[i] = params[i];
     } else if (typeof params[i] === "string") {
       sanitizedParams[i] = params[i].substring(
         0,

--- a/src/modules/utils/filterObjectForLogging.ts
+++ b/src/modules/utils/filterObjectForLogging.ts
@@ -11,6 +11,13 @@ export function filterObjectForLogging(params: object): { [key: string]: any } {
   const sanitizedParams = {};
 
   for (const i in params) {
+    if (
+      Array.isArray(params[i]) &&
+      params[i].length > (config.logger?.maxLogArrayLength ?? 10)
+    ) {
+      params[i] = `${params[i].length} items`;
+    }
+
     if (isPlainObject(params[i])) {
       sanitizedParams[i] = Object.assign({}, params[i]);
     } else if (typeof params[i] === "string") {

--- a/src/modules/utils/filterResponseForLogging.ts
+++ b/src/modules/utils/filterResponseForLogging.ts
@@ -10,11 +10,12 @@ import * as dotProp from "dot-prop";
 export function filterResponseForLogging(response: object): {
   [key: string]: any;
 } {
+  response = Object.assign({}, response);
   const sanitizedResponse = {};
 
   for (const i in response) {
     if (isPlainObject(response[i])) {
-      sanitizedResponse[i] = Object.assign({}, response[i]);
+      sanitizedResponse[i] = response[i];
     } else if (typeof response[i] === "string") {
       sanitizedResponse[i] = response[i].substring(
         0,


### PR DESCRIPTION
The new config param, `config.logging.maxLogArrayLength` can be used to limit the number of items logged for large arrays. The default value is 10.  This applies to logging the params/inputs of Actions and Tasks.