### PR TITLE
Return @types/ioredis as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@types/ioredis": "^4.26.4",
         "browser_fingerprint": "^2.0.3",
         "commander": "^7.2.0",
         "dot-prop": "^6.0.1",
@@ -34,7 +35,6 @@
       },
       "devDependencies": {
         "@types/glob": "^7.1.3",
-        "@types/ioredis": "^4.26.4",
         "@types/jest": "^26.0.23",
         "@types/node": "^15.3.0",
         "@types/primus": "^7.3.4",
@@ -1096,7 +1096,6 @@
       "version": "4.26.4",
       "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.26.4.tgz",
       "integrity": "sha512-QFbjNq7EnOGw6d1gZZt2h26OFXjx7z+eqEnbCHSrDI1OOLEgOHMKdtIajJbuCr9uO+X9kQQRe7Lz6uxqxl5XKg==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -1144,8 +1143,7 @@
     "node_modules/@types/node": {
       "version": "15.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.3.0.tgz",
-      "integrity": "sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ==",
-      "dev": true
+      "integrity": "sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.0",
@@ -9109,7 +9107,6 @@
       "version": "4.26.4",
       "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.26.4.tgz",
       "integrity": "sha512-QFbjNq7EnOGw6d1gZZt2h26OFXjx7z+eqEnbCHSrDI1OOLEgOHMKdtIajJbuCr9uO+X9kQQRe7Lz6uxqxl5XKg==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -9157,8 +9154,7 @@
     "@types/node": {
       "version": "15.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.3.0.tgz",
-      "integrity": "sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ==",
-      "dev": true
+      "integrity": "sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
+    "@types/ioredis": "^4.26.4",
     "browser_fingerprint": "^2.0.3",
     "commander": "^7.2.0",
     "dot-prop": "^6.0.1",
@@ -56,7 +57,6 @@
   },
   "devDependencies": {
     "@types/glob": "^7.1.3",
-    "@types/ioredis": "^4.26.4",
     "@types/jest": "^26.0.23",
     "@types/node": "^15.3.0",
     "@types/primus": "^7.3.4",


### PR DESCRIPTION
In https://github.com/actionhero/actionhero/pull/1831, `@types/ioredis` was improperly moved to a devDependency.  This PR fixes it.