### PR TITLE
Better types for ExceptionReporter & use throughout

### DIFF
--- a/src/classes/exceptionReporter.ts
+++ b/src/classes/exceptionReporter.ts
@@ -1,0 +1,7 @@
+export type ExceptionReporter = (
+  error: Error,
+  type: string,
+  name: string,
+  objects?: any,
+  severity?: string
+) => void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { Api } from "./classes/api";
 export { Process } from "./classes/process";
 export { Initializer } from "./classes/initializer";
 export { Connection } from "./classes/connection";
+export { ExceptionReporter } from "./classes/exceptionReporter";
 export { Action } from "./classes/action";
 export { Task } from "./classes/task";
 export { Server } from "./classes/server";

--- a/src/initializers/actions.ts
+++ b/src/initializers/actions.ts
@@ -84,7 +84,7 @@ export class Actions extends Initializer {
         }
       } catch (error) {
         try {
-          api.exceptionHandlers.loader(fullFilePath, error);
+          api.exceptionHandlers.initializer(error, fullFilePath);
           delete api.actions.actions[action.name][action.version];
         } catch (_error) {
           throw error;


### PR DESCRIPTION
This PR refactors the Exception initializer and introduces some better types for a new `ExceptionReporter` type.  We then use `api.exceptionHandlers.report()` in the main process if something goes wrong rather than manually logging errors to the logger as we had been.

This PR's goal is to set up the `ExceptionReporter` for use elsewhere - eg perhaps you are using Sequelize which has [custom error types](https://sequelize.org/master/class/lib/errors/validation-error.js~ValidationError.html), and you want to make a new custom `ExceptionReporter` that gets these Sequelize errors and logs the SQL statement which caused the problem... hypothetically. 