### PR TITLE
If there is no `error.stack`, use the error message

### DIFF
--- a/src/initializers/exceptions.ts
+++ b/src/initializers/exceptions.ts
@@ -107,7 +107,11 @@ export class Exceptions extends Initializer {
         data["data"] = objects;
       }
 
-      data["stack"] = error?.stack;
+      if (error["stack"]) {
+        data["stack"] = error.stack;
+      } else {
+        data["stack"] = error.message ?? error.toString();
+      }
 
       try {
         if (message) log(message, severity, data);


### PR DESCRIPTION
This PR extends https://github.com/actionhero/actionhero/pull/1853, updating the ExceptionReporter to always have a value for `data.stack`, even if the Error object doesn't have a stack trace.  In that case, we'll use `error.message` or `error.toString()`