### PR TITLE
Action Logging Improvements to aid `404` debugging

### DIFF
--- a/src/classes/actionProcessor.ts
+++ b/src/classes/actionProcessor.ts
@@ -137,9 +137,9 @@ export class ActionProcessor<ActionClass extends Action> {
       action: this.action,
       params: JSON.stringify(filteredParams),
       duration: this.duration,
-      error: "",
       method: type === "web" ? rawConnection.method : undefined,
       pathname: type === "web" ? rawConnection.parsedURL.pathname : undefined,
+      error: "",
       response: undefined,
     };
 

--- a/src/classes/actionProcessor.ts
+++ b/src/classes/actionProcessor.ts
@@ -160,7 +160,10 @@ export class ActionProcessor<ActionClass extends Action> {
 
     log(`[ action @ ${this.connection.type} ]`, logLevel, logLine);
 
-    if (error && status !== "unknown_action") {
+    if (
+      error &&
+      (status !== "unknown_action" || config.errors.reportUnknownActions)
+    ) {
       api.exceptionHandlers.action(error, logLine);
     }
   }

--- a/src/classes/actionProcessor.ts
+++ b/src/classes/actionProcessor.ts
@@ -83,8 +83,6 @@ export class ActionProcessor<ActionClass extends Action> {
     let error: Error = null;
     this.actionStatus = status;
 
-    if (typeof _error === "string") _error = new Error(_error);
-
     if (status === "generic_error") {
       error =
         typeof config.errors.genericError === "function"
@@ -105,6 +103,8 @@ export class ActionProcessor<ActionClass extends Action> {
     } else if (status) {
       error = _error;
     }
+
+    if (typeof error === "string") error = new Error(error);
 
     if (error && (typeof this.response === "string" || !this.response.error)) {
       if (typeof this.response === "string" || Array.isArray(this.response)) {

--- a/src/classes/actionProcessor.ts
+++ b/src/classes/actionProcessor.ts
@@ -5,7 +5,6 @@ import { log } from "../modules/log";
 import { utils } from "../modules/utils";
 import * as dotProp from "dot-prop";
 import { api } from "../index";
-import { stat } from "fs";
 
 export type ErrorStatusMessage =
   | "complete"

--- a/src/config/errors.ts
+++ b/src/config/errors.ts
@@ -3,6 +3,9 @@ export const DEFAULT = {
     return {
       _toExpand: false,
 
+      // Should error types of "unknownAction" be included to the Exception handlers?
+      reportUnknownActions: false,
+
       // ///////////////
       // SERIALIZERS //
       // ///////////////

--- a/src/config/errors.ts
+++ b/src/config/errors.ts
@@ -41,9 +41,7 @@ export const DEFAULT = {
 
       // When a params for an action is invalid
       invalidParams: (data, validationErrors) => {
-        if (validationErrors.length >= 0) {
-          return validationErrors[0];
-        }
+        if (validationErrors.length >= 0) return validationErrors[0];
         return data.connection.localize("actionhero.errors.invalidParams");
       },
 

--- a/src/servers/web.ts
+++ b/src/servers/web.ts
@@ -11,6 +11,7 @@ import * as uuid from "uuid";
 import * as etag from "etag";
 import { BrowserFingerprint } from "browser_fingerprint";
 import { api, config, utils, Server, Connection } from "../index";
+import { ActionsStatus } from "../classes/actionProcessor";
 
 export class WebServer extends Server {
   server: http.Server | https.Server;
@@ -502,9 +503,9 @@ export class WebServer extends Server {
           customErrorCode >= 100 && customErrorCode < 600;
         if (isValidCustomResponseCode) {
           data.connection.rawConnection.responseHttpCode = customErrorCode;
-        } else if (data.actionStatus === "unknown_action") {
+        } else if (data.actionStatus === ActionsStatus.UnknownAction) {
           data.connection.rawConnection.responseHttpCode = 404;
-        } else if (data.actionStatus === "missing_params") {
+        } else if (data.actionStatus === ActionsStatus.MissingParams) {
           data.connection.rawConnection.responseHttpCode = 422;
         } else {
           data.connection.rawConnection.responseHttpCode =


### PR DESCRIPTION
This PR improves a few things about Action logging:

1. [Enhancement] Action logs now include the `method` and `pathname` of the request, as seen by Actionhero, for web connections.

```
2021-06-30T00:05:53.156Z - info: [ action @ web ] to=127.0.0.1 action=createChatRoom params={"action":"createChatRoom","apiVersion":1,"name":"some room"} duration=1 method=GET pathname=/api/createChatRoom

2021-06-30T00:05:42.163Z - error: [ action @ web ] to=127.0.0.1 action=createChatRoom params={"action":"createChatRoom","apiVersion":1,"name":"foo"} duration=1 error=Error: room exists method=GET pathname=/api/createChatRoom stack=Error: room exists
    at Object.add (/Users/evan/workspace/actionhero/actionhero/src/modules/chatRoom.ts:111:13)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at CreateChatRoom.run (/Users/evan/workspace/actionhero/actionhero/src/actions/createChatRoom.ts:16:25)
    at ActionProcessor.runAction (/Users/evan/workspace/actionhero/actionhero/src/classes/actionProcessor.ts:427:32)
    at WebServer.processAction (/Users/evan/workspace/actionhero/actionhero/src/classes/server.ts:229:18)
```

2. [Breaking-ish] Errors of the type `unknown_action`, which normally produce a localized error of `"unknown action or invalid apiVersion"`, are no longer sent to the error reporter by default.  This is configured by the new `config.errors.reportUnknownActions` config setting.  When disabled (`config.errors.reportUnknownActions=false`), this means that the error will still be logged just as it was before, but if you are using an additional error reporter, like New Relic or Sentry, it will not get these error types.  
 
```
2021-06-30T00:07:18.938Z - error: [ action @ web ] to=127.0.0.1 params={"action":null,"apiVersion":null} duration=0 error=Error: unknown action or invalid apiVersion method=GET pathname=/api/not/a/real/thing stack=Error: unknown action or invalid apiVersion
    at ActionProcessor.completeAction (/Users/evan/workspace/actionhero/actionhero/src/classes/actionProcessor.ts:107:44)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

With these 2 improvements, it should be easier to debug 404s! 