### PR TITLE
Update Test templates and SpecHelper Types

### DIFF
--- a/__tests__/actions/cacheTest.ts
+++ b/__tests__/actions/cacheTest.ts
@@ -1,87 +1,79 @@
 import { Process, specHelper } from "./../../src/index";
 import { CacheTest } from "../../src/actions/cacheTest";
 
-const RunMethod = CacheTest.prototype.run;
-const actionhero = new Process();
+describe("Action: Cache", () => {
+  const RunMethod = CacheTest.prototype.run;
+  const actionhero = new Process();
 
-describe("Action", () => {
-  describe("Cache", () => {
-    beforeAll(async () => {
-      await actionhero.start();
-    });
+  beforeAll(async () => {
+    await actionhero.start();
+  });
 
-    afterAll(async () => {
-      await actionhero.stop();
-    });
+  afterAll(async () => {
+    await actionhero.stop();
+  });
 
-    test("fails with no params", async () => {
-      const { error } = await specHelper.runAction<typeof RunMethod>(
-        "cacheTest",
-        {}
-      );
-      expect(error).toEqual(
-        "Error: key is a required parameter for this action"
-      );
-    });
+  test("fails with no params", async () => {
+    const { error } = await specHelper.runAction<typeof RunMethod>(
+      "cacheTest",
+      {}
+    );
+    expect(error).toEqual("Error: key is a required parameter for this action");
+  });
 
-    test("fails with just key", async () => {
-      const { error } = await specHelper.runAction<typeof RunMethod>(
-        "cacheTest",
-        {
-          key: "test key",
-        }
-      );
-      expect(error).toEqual(
-        "Error: value is a required parameter for this action"
-      );
-    });
+  test("fails with just key", async () => {
+    const { error } = await specHelper.runAction<typeof RunMethod>(
+      "cacheTest",
+      {
+        key: "test key",
+      }
+    );
+    expect(error).toEqual(
+      "Error: value is a required parameter for this action"
+    );
+  });
 
-    test("fails with just value", async () => {
-      const { error } = await specHelper.runAction<typeof RunMethod>(
-        "cacheTest",
-        {
-          value: "abc123",
-        }
-      );
-      expect(error).toEqual(
-        "Error: key is a required parameter for this action"
-      );
-    });
-
-    test("fails with gibberish param", async () => {
-      const { error } = await specHelper.runAction<typeof RunMethod>(
-        "cacheTest",
-        {
-          thingy: "abc123",
-        }
-      );
-      expect(error).toEqual(
-        "Error: key is a required parameter for this action"
-      );
-    });
-
-    test("fails with value shorter than 2 letters", async () => {
-      const { error } = await specHelper.runAction<typeof RunMethod>(
-        "cacheTest",
-        {
-          key: "abc123",
-          value: "v",
-        }
-      );
-      expect(error).toEqual("Error: inputs should be at least 3 letters long");
-    });
-
-    test("works with correct params", async () => {
-      const { cacheTestResults, error } = await specHelper.runAction<
-        typeof RunMethod
-      >("cacheTest", {
-        key: "testKey",
+  test("fails with just value", async () => {
+    const { error } = await specHelper.runAction<typeof RunMethod>(
+      "cacheTest",
+      {
         value: "abc123",
-      });
-      expect(error).toBeFalsy();
-      expect(cacheTestResults.saveResp).toEqual(true);
-      expect(cacheTestResults.loadResp.value).toEqual("abc123");
-      expect(cacheTestResults.deleteResp).toEqual(true);
+      }
+    );
+    expect(error).toEqual("Error: key is a required parameter for this action");
+  });
+
+  test("fails with gibberish param", async () => {
+    const { error } = await specHelper.runAction<typeof RunMethod>(
+      "cacheTest",
+      {
+        thingy: "abc123",
+      }
+    );
+    expect(error).toEqual("Error: key is a required parameter for this action");
+  });
+
+  test("fails with value shorter than 2 letters", async () => {
+    const { error } = await specHelper.runAction<typeof RunMethod>(
+      "cacheTest",
+      {
+        key: "abc123",
+        value: "v",
+      }
+    );
+    expect(error).toEqual("Error: inputs should be at least 3 letters long");
+  });
+
+  test("works with correct params", async () => {
+    const { cacheTestResults, error } = await specHelper.runAction<
+      typeof RunMethod
+    >("cacheTest", {
+      key: "testKey",
+      value: "abc123",
     });
+    expect(error).toBeFalsy();
+    expect(cacheTestResults.saveResp).toEqual(true);
+    expect(cacheTestResults.loadResp.value).toEqual("abc123");
+    expect(cacheTestResults.deleteResp).toEqual(true);
   });
 });

--- a/__tests__/actions/cacheTest.ts
+++ b/__tests__/actions/cacheTest.ts
@@ -2,75 +2,54 @@ import { Process, specHelper } from "./../../src/index";
 import { CacheTest } from "../../src/actions/cacheTest";
 
 describe("Action: Cache", () => {
-  const RunMethod = CacheTest.prototype.run;
   const actionhero = new Process();
-
-  beforeAll(async () => {
-    await actionhero.start();
-  });
-
-  afterAll(async () => {
-    await actionhero.stop();
-  });
+  beforeAll(async () => await actionhero.start());
+  afterAll(async () => await actionhero.stop());
 
   test("fails with no params", async () => {
-    const { error } = await specHelper.runAction<typeof RunMethod>(
-      "cacheTest",
-      {}
-    );
+    const { error } = await specHelper.runAction<CacheTest>("cacheTest", {});
     expect(error).toEqual("Error: key is a required parameter for this action");
   });
 
   test("fails with just key", async () => {
-    const { error } = await specHelper.runAction<typeof RunMethod>(
-      "cacheTest",
-      {
-        key: "test key",
-      }
-    );
+    const { error } = await specHelper.runAction<CacheTest>("cacheTest", {
+      key: "test key",
+    });
     expect(error).toEqual(
       "Error: value is a required parameter for this action"
     );
   });
 
   test("fails with just value", async () => {
-    const { error } = await specHelper.runAction<typeof RunMethod>(
-      "cacheTest",
-      {
-        value: "abc123",
-      }
-    );
+    const { error } = await specHelper.runAction<CacheTest>("cacheTest", {
+      value: "abc123",
+    });
     expect(error).toEqual("Error: key is a required parameter for this action");
   });
 
   test("fails with gibberish param", async () => {
-    const { error } = await specHelper.runAction<typeof RunMethod>(
-      "cacheTest",
-      {
-        thingy: "abc123",
-      }
-    );
+    const { error } = await specHelper.runAction<CacheTest>("cacheTest", {
+      thingy: "abc123",
+    });
     expect(error).toEqual("Error: key is a required parameter for this action");
   });
 
   test("fails with value shorter than 2 letters", async () => {
-    const { error } = await specHelper.runAction<typeof RunMethod>(
-      "cacheTest",
-      {
-        key: "abc123",
-        value: "v",
-      }
-    );
+    const { error } = await specHelper.runAction<CacheTest>("cacheTest", {
+      key: "abc123",
+      value: "v",
+    });
     expect(error).toEqual("Error: inputs should be at least 3 letters long");
   });
 
   test("works with correct params", async () => {
-    const { cacheTestResults, error } = await specHelper.runAction<
-      typeof RunMethod
-    >("cacheTest", {
-      key: "testKey",
-      value: "abc123",
-    });
+    const { cacheTestResults, error } = await specHelper.runAction<CacheTest>(
+      "cacheTest",
+      {
+        key: "testKey",
+        value: "abc123",
+      }
+    );
     expect(error).toBeFalsy();
     expect(cacheTestResults.saveResp).toEqual(true);
     expect(cacheTestResults.loadResp.value).toEqual("abc123");

--- a/__tests__/actions/randomNumber.ts
+++ b/__tests__/actions/randomNumber.ts
@@ -2,21 +2,14 @@ import { Process, specHelper } from "./../../src/index";
 import { RandomNumber } from "../../src/actions/randomNumber";
 
 describe("Action: randomNumber", () => {
-  const RunMethod = RandomNumber.prototype.run;
   const actionhero = new Process();
-
-  beforeAll(async () => {
-    await actionhero.start();
-  });
-
-  afterAll(async () => {
-    await actionhero.stop();
-  });
+  beforeAll(async () => await actionhero.start());
+  afterAll(async () => await actionhero.stop());
 
   let firstNumber = null;
 
   test("generates random numbers", async () => {
-    const { randomNumber } = await specHelper.runAction<typeof RunMethod>(
+    const { randomNumber } = await specHelper.runAction<RandomNumber>(
       "randomNumber"
     );
     expect(randomNumber).toBeGreaterThan(0);
@@ -25,7 +18,7 @@ describe("Action: randomNumber", () => {
   });
 
   test("is unique / random", async () => {
-    const { randomNumber } = await specHelper.runAction<typeof RunMethod>(
+    const { randomNumber } = await specHelper.runAction<RandomNumber>(
       "randomNumber"
     );
     expect(randomNumber).toBeGreaterThan(0);

--- a/__tests__/actions/randomNumber.ts
+++ b/__tests__/actions/randomNumber.ts
@@ -1,37 +1,35 @@
 import { Process, specHelper } from "./../../src/index";
 import { RandomNumber } from "../../src/actions/randomNumber";
 
-const RunMethod = RandomNumber.prototype.run;
-const actionhero = new Process();
+describe("Action: randomNumber", () => {
+  const RunMethod = RandomNumber.prototype.run;
+  const actionhero = new Process();
 
-describe("Action", () => {
-  describe("randomNumber", () => {
-    beforeAll(async () => {
-      await actionhero.start();
-    });
+  beforeAll(async () => {
+    await actionhero.start();
+  });
 
-    afterAll(async () => {
-      await actionhero.stop();
-    });
+  afterAll(async () => {
+    await actionhero.stop();
+  });
 
-    let firstNumber = null;
+  let firstNumber = null;
 
-    test("generates random numbers", async () => {
-      const { randomNumber } = await specHelper.runAction<typeof RunMethod>(
-        "randomNumber"
-      );
-      expect(randomNumber).toBeGreaterThan(0);
-      expect(randomNumber).toBeLessThan(1);
-      firstNumber = randomNumber;
-    });
+  test("generates random numbers", async () => {
+    const { randomNumber } = await specHelper.runAction<typeof RunMethod>(
+      "randomNumber"
+    );
+    expect(randomNumber).toBeGreaterThan(0);
+    expect(randomNumber).toBeLessThan(1);
+    firstNumber = randomNumber;
+  });
 
-    test("is unique / random", async () => {
-      const { randomNumber } = await specHelper.runAction<typeof RunMethod>(
-        "randomNumber"
-      );
-      expect(randomNumber).toBeGreaterThan(0);
-      expect(randomNumber).toBeLessThan(1);
-      expect(randomNumber).not.toEqual(firstNumber);
-    });
+  test("is unique / random", async () => {
+    const { randomNumber } = await specHelper.runAction<typeof RunMethod>(
+      "randomNumber"
+    );
+    expect(randomNumber).toBeGreaterThan(0);
+    expect(randomNumber).toBeLessThan(1);
+    expect(randomNumber).not.toEqual(firstNumber);
   });
 });

--- a/__tests__/actions/recursiveAction.ts
+++ b/__tests__/actions/recursiveAction.ts
@@ -1,26 +1,24 @@
 import { Process, specHelper } from "./../../src/index";
 import { RecursiveAction } from "../../src/actions/recursiveAction";
 
-const RunMethod = RecursiveAction.prototype.run;
-const actionhero = new Process();
+describe("Action: recursiveAction", () => {
+  const RunMethod = RecursiveAction.prototype.run;
+  const actionhero = new Process();
 
-describe("Action", () => {
-  describe("recursiveAction", () => {
-    beforeAll(async () => {
-      await actionhero.start();
-    });
+  beforeAll(async () => {
+    await actionhero.start();
+  });
 
-    afterAll(async () => {
-      await actionhero.stop();
-    });
+  afterAll(async () => {
+    await actionhero.stop();
+  });
 
-    test("merges its own response with the randomNumber response", async () => {
-      const response = await specHelper.runAction<typeof RunMethod>(
-        "recursiveAction"
-      );
-      expect(response.local).toEqual(true);
-      expect(response.randomNumber).toBeGreaterThanOrEqual(0);
-      expect(response.stringRandomNumber).toMatch(/Your random number is/);
-    });
+  test("merges its own response with the randomNumber response", async () => {
+    const response = await specHelper.runAction<typeof RunMethod>(
+      "recursiveAction"
+    );
+    expect(response.local).toEqual(true);
+    expect(response.randomNumber).toBeGreaterThanOrEqual(0);
+    expect(response.stringRandomNumber).toMatch(/Your random number is/);
   });
 });

--- a/__tests__/actions/recursiveAction.ts
+++ b/__tests__/actions/recursiveAction.ts
@@ -2,19 +2,12 @@ import { Process, specHelper } from "./../../src/index";
 import { RecursiveAction } from "../../src/actions/recursiveAction";
 
 describe("Action: recursiveAction", () => {
-  const RunMethod = RecursiveAction.prototype.run;
   const actionhero = new Process();
-
-  beforeAll(async () => {
-    await actionhero.start();
-  });
-
-  afterAll(async () => {
-    await actionhero.stop();
-  });
+  beforeAll(async () => await actionhero.start());
+  afterAll(async () => await actionhero.stop());
 
   test("merges its own response with the randomNumber response", async () => {
-    const response = await specHelper.runAction<typeof RunMethod>(
+    const response = await specHelper.runAction<RecursiveAction>(
       "recursiveAction"
     );
     expect(response.local).toEqual(true);

--- a/__tests__/actions/sleepTest.ts
+++ b/__tests__/actions/sleepTest.ts
@@ -1,34 +1,32 @@
 import { Process, specHelper } from "./../../src/index";
 import { SleepTest } from "../../src/actions/sleepTest";
 
-const RunMethod = SleepTest.prototype.run;
-const actionhero = new Process();
+describe("Action: sleepTest", () => {
+  const RunMethod = SleepTest.prototype.run;
+  const actionhero = new Process();
 
-describe("Action", () => {
-  describe("sleepTest", () => {
-    beforeAll(async () => {
-      await actionhero.start();
-    });
+  beforeAll(async () => {
+    await actionhero.start();
+  });
 
-    afterAll(async () => {
-      await actionhero.stop();
-    });
+  afterAll(async () => {
+    await actionhero.stop();
+  });
 
-    test("will return data from an async action", async () => {
-      const { sleepDuration } = await specHelper.runAction<typeof RunMethod>(
-        "sleepTest"
-      );
-      expect(sleepDuration).toEqual(1000);
-    });
+  test("will return data from an async action", async () => {
+    const { sleepDuration } = await specHelper.runAction<typeof RunMethod>(
+      "sleepTest"
+    );
+    expect(sleepDuration).toEqual(1000);
+  });
 
-    test("can change sleepDuration", async () => {
-      const { sleepDuration } = await specHelper.runAction<typeof RunMethod>(
-        "sleepTest",
-        {
-          sleepDuration: 100,
-        }
-      );
-      expect(sleepDuration).toEqual(100);
-    });
+  test("can change sleepDuration", async () => {
+    const { sleepDuration } = await specHelper.runAction<typeof RunMethod>(
+      "sleepTest",
+      {
+        sleepDuration: 100,
+      }
+    );
+    expect(sleepDuration).toEqual(100);
   });
 });

--- a/__tests__/actions/sleepTest.ts
+++ b/__tests__/actions/sleepTest.ts
@@ -2,26 +2,19 @@ import { Process, specHelper } from "./../../src/index";
 import { SleepTest } from "../../src/actions/sleepTest";
 
 describe("Action: sleepTest", () => {
-  const RunMethod = SleepTest.prototype.run;
   const actionhero = new Process();
-
-  beforeAll(async () => {
-    await actionhero.start();
-  });
-
-  afterAll(async () => {
-    await actionhero.stop();
-  });
+  beforeAll(async () => await actionhero.start());
+  afterAll(async () => await actionhero.stop());
 
   test("will return data from an async action", async () => {
-    const { sleepDuration } = await specHelper.runAction<typeof RunMethod>(
+    const { sleepDuration } = await specHelper.runAction<SleepTest>(
       "sleepTest"
     );
     expect(sleepDuration).toEqual(1000);
   });
 
   test("can change sleepDuration", async () => {
-    const { sleepDuration } = await specHelper.runAction<typeof RunMethod>(
+    const { sleepDuration } = await specHelper.runAction<SleepTest>(
       "sleepTest",
       {
         sleepDuration: 100,

--- a/__tests__/actions/status.ts
+++ b/__tests__/actions/status.ts
@@ -1,27 +1,25 @@
 import { Process, specHelper } from "./../../src/index";
 import { Status } from "../../src/actions/status";
 
-const RunMethod = Status.prototype.run;
-const actionhero = new Process();
+describe("Action: status", () => {
+  const actionhero = new Process();
+  const RunMethod = Status.prototype.run;
 
-describe("Action", () => {
-  describe("status", () => {
-    beforeAll(async () => {
-      await actionhero.start();
-    });
+  beforeAll(async () => {
+    await actionhero.start();
+  });
 
-    afterAll(async () => {
-      await actionhero.stop();
-    });
+  afterAll(async () => {
+    await actionhero.stop();
+  });
 
-    test("returns node status", async () => {
-      const { id, problems, name, error } = await specHelper.runAction<
-        typeof RunMethod
-      >("status");
-      expect(error).toBeUndefined();
-      expect(problems).toHaveLength(0);
-      expect(id).toEqual(`test-server-${process.env.JEST_WORKER_ID || 0}`);
-      expect(name).toEqual("actionhero");
-    });
+  test("returns node status", async () => {
+    const { id, problems, name, error } = await specHelper.runAction<
+      typeof RunMethod
+    >("status");
+    expect(error).toBeUndefined();
+    expect(problems).toHaveLength(0);
+    expect(id).toEqual(`test-server-${process.env.JEST_WORKER_ID || 0}`);
+    expect(name).toEqual("actionhero");
   });
 });

--- a/__tests__/actions/status.ts
+++ b/__tests__/actions/status.ts
@@ -3,20 +3,13 @@ import { Status } from "../../src/actions/status";
 
 describe("Action: status", () => {
   const actionhero = new Process();
-  const RunMethod = Status.prototype.run;
-
-  beforeAll(async () => {
-    await actionhero.start();
-  });
-
-  afterAll(async () => {
-    await actionhero.stop();
-  });
+  beforeAll(async () => await actionhero.start());
+  afterAll(async () => await actionhero.stop());
 
   test("returns node status", async () => {
-    const { id, problems, name, error } = await specHelper.runAction<
-      typeof RunMethod
-    >("status");
+    const { id, problems, name, error } = await specHelper.runAction<Status>(
+      "status"
+    );
     expect(error).toBeUndefined();
     expect(problems).toHaveLength(0);
     expect(id).toEqual(`test-server-${process.env.JEST_WORKER_ID || 0}`);

--- a/__tests__/actions/swagger.ts
+++ b/__tests__/actions/swagger.ts
@@ -1,27 +1,25 @@
 import { Process, specHelper } from "./../../src/index";
 import { Swagger } from "../../src/actions/swagger";
 
-const RunMethod = Swagger.prototype.run;
-const actionhero = new Process();
+describe("Action: swagger", () => {
+  const RunMethod = Swagger.prototype.run;
+  const actionhero = new Process();
 
-describe("Action", () => {
-  describe("swagger", () => {
-    beforeAll(async () => {
-      process.env.AUTOMATIC_ROUTES = "get";
-      await actionhero.start();
-    });
+  beforeAll(async () => {
+    process.env.AUTOMATIC_ROUTES = "get";
+    await actionhero.start();
+  });
 
-    afterAll(async () => {
-      await actionhero.stop();
-    });
+  afterAll(async () => {
+    await actionhero.stop();
+  });
 
-    test("returns the correct parts", async () => {
-      const { paths, basePath, host } = await specHelper.runAction<
-        typeof RunMethod
-      >("swagger");
-      expect(basePath).toBe("/api/");
-      expect(host).toMatch(/localhost/);
-      expect(Object.keys(paths).length).toEqual(9); // 9 actions
-    });
+  test("returns the correct parts", async () => {
+    const { paths, basePath, host } = await specHelper.runAction<
+      typeof RunMethod
+    >("swagger");
+    expect(basePath).toBe("/api/");
+    expect(host).toMatch(/localhost/);
+    expect(Object.keys(paths).length).toEqual(9); // 9 actions
   });
 });

--- a/__tests__/actions/swagger.ts
+++ b/__tests__/actions/swagger.ts
@@ -2,22 +2,18 @@ import { Process, specHelper } from "./../../src/index";
 import { Swagger } from "../../src/actions/swagger";
 
 describe("Action: swagger", () => {
-  const RunMethod = Swagger.prototype.run;
   const actionhero = new Process();
-
   beforeAll(async () => {
     process.env.AUTOMATIC_ROUTES = "get";
     await actionhero.start();
   });
 
-  afterAll(async () => {
-    await actionhero.stop();
-  });
+  afterAll(async () => await actionhero.stop());
 
   test("returns the correct parts", async () => {
-    const { paths, basePath, host } = await specHelper.runAction<
-      typeof RunMethod
-    >("swagger");
+    const { paths, basePath, host } = await specHelper.runAction<Swagger>(
+      "swagger"
+    );
     expect(basePath).toBe("/api/");
     expect(host).toMatch(/localhost/);
     expect(Object.keys(paths).length).toEqual(9); // 9 actions

--- a/__tests__/actions/validationTest.ts
+++ b/__tests__/actions/validationTest.ts
@@ -1,44 +1,48 @@
 import { Process, specHelper } from "./../../src/index";
 import { ValidationTest } from "../../src/actions/validationTest";
 
-const RunMethod = ValidationTest.prototype.run;
-const actionhero = new Process();
+describe("Action: validationTest", () => {
+  const RunMethod = ValidationTest.prototype.run;
+  const actionhero = new Process();
 
-describe("Action", () => {
-  describe("validationTest", () => {
-    beforeAll(async () => {
-      await actionhero.start();
-    });
+  beforeAll(async () => {
+    await actionhero.start();
+  });
 
-    afterAll(async () => {
-      await actionhero.stop();
-    });
+  afterAll(async () => {
+    await actionhero.stop();
+  });
 
-    test("fails with no params", async () => {
-      const { error } = await specHelper.runAction("validationTest", {});
-      expect(error).toEqual(
-        "Error: string is a required parameter for this action"
-      );
-    });
+  test("fails with no params", async () => {
+    const { error } = await specHelper.runAction<typeof RunMethod>(
+      "validationTest",
+      {}
+    );
+    expect(error).toEqual(
+      "Error: string is a required parameter for this action"
+    );
+  });
 
-    test("fails with a number", async () => {
-      const { error } = await specHelper.runAction("validationTest", {
+  test("fails with a number", async () => {
+    const { error } = await specHelper.runAction<typeof RunMethod>(
+      "validationTest",
+      {
         string: 87,
-      });
-      expect(error).toEqual(
-        'Error: Input for parameter "string" failed validation!'
-      );
-    });
+      }
+    );
+    expect(error).toEqual(
+      'Error: Input for parameter "string" failed validation!'
+    );
+  });
 
-    test("works with a string", async () => {
-      const { string } = await specHelper.runAction<typeof RunMethod>(
-        "validationTest",
-        {
-          string: "hello",
-          ValidationTest,
-        }
-      );
-      expect(string).toEqual("hello");
-    });
+  test("works with a string", async () => {
+    const { string } = await specHelper.runAction<typeof RunMethod>(
+      "validationTest",
+      {
+        string: "hello",
+        ValidationTest,
+      }
+    );
+    expect(string).toEqual("hello");
   });
 });

--- a/__tests__/actions/validationTest.ts
+++ b/__tests__/actions/validationTest.ts
@@ -2,19 +2,12 @@ import { Process, specHelper } from "./../../src/index";
 import { ValidationTest } from "../../src/actions/validationTest";
 
 describe("Action: validationTest", () => {
-  const RunMethod = ValidationTest.prototype.run;
   const actionhero = new Process();
-
-  beforeAll(async () => {
-    await actionhero.start();
-  });
-
-  afterAll(async () => {
-    await actionhero.stop();
-  });
+  beforeAll(async () => await actionhero.start());
+  afterAll(async () => await actionhero.stop());
 
   test("fails with no params", async () => {
-    const { error } = await specHelper.runAction<typeof RunMethod>(
+    const { error } = await specHelper.runAction<ValidationTest>(
       "validationTest",
       {}
     );
@@ -24,7 +17,7 @@ describe("Action: validationTest", () => {
   });
 
   test("fails with a number", async () => {
-    const { error } = await specHelper.runAction<typeof RunMethod>(
+    const { error } = await specHelper.runAction<ValidationTest>(
       "validationTest",
       {
         string: 87,
@@ -36,7 +29,7 @@ describe("Action: validationTest", () => {
   });
 
   test("works with a string", async () => {
-    const { string } = await specHelper.runAction<typeof RunMethod>(
+    const { string } = await specHelper.runAction<ValidationTest>(
       "validationTest",
       {
         string: "hello",

--- a/__tests__/core/api.ts
+++ b/__tests__/core/api.ts
@@ -310,7 +310,7 @@ describe("Core", () => {
       });
 
       test("will set a default when params are not provided", async () => {
-        const response = await specHelper.runAction("testAction", {
+        const response = await specHelper.runAction<any>("testAction", {
           requiredParam: true,
         });
         expect(response.params.fancyParam).toEqual("abc123");
@@ -454,7 +454,7 @@ describe("Core", () => {
       });
 
       test("will set a default when params are not provided", async () => {
-        const response = await specHelper.runAction("testAction", {
+        const response = await specHelper.runAction<any>("testAction", {
           schemaParam: { requiredParam: true },
         });
         expect(response.params.schemaParam.fancyParam).toEqual("abc123");
@@ -597,7 +597,9 @@ describe("Core", () => {
       });
 
       test("runs formatter arrays in the proper order", async () => {
-        const response = await specHelper.runAction("testAction", { a: 6 });
+        const response = await specHelper.runAction<any>("testAction", {
+          a: 6,
+        });
         expect(response.a).toEqual("~*6*~");
       });
     });
@@ -627,7 +629,7 @@ describe("Core", () => {
       });
 
       test("prevents data.params from being modified", async () => {
-        const response = await specHelper.runAction("testAction", {
+        const response = await specHelper.runAction<any>("testAction", {
           a: "original",
         });
         expect(response.a).toBeUndefined();

--- a/__tests__/core/cli.ts
+++ b/__tests__/core/cli.ts
@@ -231,7 +231,7 @@ describe("Core: CLI", () => {
         const testData = String(
           fs.readFileSync(`${testDir}/__tests__/actions/myAction.ts`)
         );
-        expect(testData).toMatch('describe("myAction"');
+        expect(testData).toMatch('describe("Action: myAction"');
       }, 20000);
 
       test("can generate a task", async () => {
@@ -249,7 +249,7 @@ describe("Core: CLI", () => {
         const testData = String(
           fs.readFileSync(`${testDir}/__tests__/tasks/myTask.ts`)
         );
-        expect(testData).toMatch('describe("myTask"');
+        expect(testData).toMatch('describe("Task: myTask"');
       }, 20000);
 
       test("can generate a CLI command", async () => {

--- a/__tests__/core/cluster.ts
+++ b/__tests__/core/cluster.ts
@@ -26,9 +26,7 @@ describe("Core: Action Cluster", () => {
     }
   });
 
-  afterAll(async () => {
-    await actionhero.stop();
-  });
+  afterAll(async () => await actionhero.stop());
 
   describe("RPC", () => {
     afterEach(() => {

--- a/__tests__/core/errors.ts
+++ b/__tests__/core/errors.ts
@@ -81,7 +81,7 @@ describe("Core", () => {
     });
 
     test("will return an actions error", async () => {
-      const response = await specHelper.runAction("errorAction");
+      const response = await specHelper.runAction<any>("errorAction");
       expect(response.error).toEqual("Error: worst action ever!");
       expect(response.requestId).toBeUndefined();
     });
@@ -91,7 +91,7 @@ describe("Core", () => {
         data.response.requestId = "id-12345";
         return error;
       };
-      const response = await specHelper.runAction("errorAction");
+      const response = await specHelper.runAction<any>("errorAction");
       expect(response.error).toEqual("Error: worst action ever!");
       expect(response.requestId).toEqual("id-12345");
     });

--- a/__tests__/core/i18n.ts
+++ b/__tests__/core/i18n.ts
@@ -1,14 +1,8 @@
 import * as I18n from "i18n";
 import * as fs from "fs";
 import * as path from "path";
-import {
-  api,
-  Process,
-  config,
-  i18n,
-  utils,
-  specHelper,
-} from "./../../src/index";
+import { Process, config, i18n, utils, specHelper } from "./../../src/index";
+import { RandomNumber } from "../../src/actions/randomNumber";
 
 const actionhero = new Process();
 let originalDetermineConnectionLocale;
@@ -57,7 +51,9 @@ describe("Core", () => {
     });
 
     test("should create localization files by default, and strings from actions should be included", async () => {
-      const { randomNumber } = await specHelper.runAction("randomNumber");
+      const { randomNumber } = await specHelper.runAction<RandomNumber>(
+        "randomNumber"
+      );
       expect(randomNumber).toBeLessThan(1);
       expect(randomNumber).toBeGreaterThanOrEqual(0);
 

--- a/__tests__/core/middleware.ts
+++ b/__tests__/core/middleware.ts
@@ -10,12 +10,8 @@ import {
 const actionhero = new Process();
 
 describe("Core: Middleware", () => {
-  beforeAll(async () => {
-    await actionhero.start();
-  });
-  afterAll(async () => {
-    await actionhero.stop();
-  });
+  beforeAll(async () => await actionhero.start());
+  afterAll(async () => await actionhero.stop());
 
   afterEach(() => {
     api.actions.middleware = {};
@@ -32,7 +28,7 @@ describe("Core: Middleware", () => {
         },
       });
 
-      const { _preProcessorNote, error } = await specHelper.runAction(
+      const { _preProcessorNote, error } = await specHelper.runAction<any>(
         "randomNumber"
       );
       expect(error).toBeUndefined();
@@ -51,7 +47,7 @@ describe("Core: Middleware", () => {
         },
       });
 
-      const { _preProcessorNote, error } = await specHelper.runAction(
+      const { _preProcessorNote, error } = await specHelper.runAction<any>(
         "randomNumber"
       );
       expect(error).toBeUndefined();
@@ -67,7 +63,7 @@ describe("Core: Middleware", () => {
         },
       });
 
-      const { _preProcessorNote, error } = await specHelper.runAction(
+      const { _preProcessorNote, error } = await specHelper.runAction<any>(
         "randomNumber"
       );
       expect(error).toBeUndefined();
@@ -112,10 +108,10 @@ describe("Core: Middleware", () => {
           },
         });
 
-        const randomResponse = await specHelper.runAction("randomNumber");
+        const randomResponse = await specHelper.runAction<any>("randomNumber");
         expect(randomResponse.authenticatedAction).toEqual(false);
 
-        const authResponse = await specHelper.runAction("authAction");
+        const authResponse = await specHelper.runAction<any>("authAction");
         expect(authResponse.authenticatedAction).toEqual(true);
       });
 
@@ -180,7 +176,7 @@ describe("Core: Middleware", () => {
         },
       });
 
-      const response = await specHelper.runAction("randomNumber");
+      const response = await specHelper.runAction<any>("randomNumber");
       expect(response._processorNoteFirst).toEqual("first");
       expect(response._processorNoteEarly).toEqual("early");
       expect(response._processorNoteDefault).toEqual("default");
@@ -206,7 +202,7 @@ describe("Core: Middleware", () => {
         },
       });
 
-      const response = await specHelper.runAction("randomNumber");
+      const response = await specHelper.runAction<any>("randomNumber");
       expect(response._processorNoteFirst).toEqual("first");
       expect(response._processorNoteSecond).toEqual("second");
     });
@@ -220,7 +216,7 @@ describe("Core: Middleware", () => {
         },
       });
 
-      const response = await specHelper.runAction("randomNumber");
+      const response = await specHelper.runAction<any>("randomNumber");
       expect(response._postProcessorNote).toEqual("note");
     });
 
@@ -270,7 +266,7 @@ describe("Core: Middleware", () => {
         },
       });
 
-      const response = await specHelper.runAction("randomNumber");
+      const response = await specHelper.runAction<any>("randomNumber");
       expect(response._processorNoteFirst).toEqual("first");
       expect(response._processorNoteEarly).toEqual("early");
       expect(response._processorNoteDefault).toEqual("default");
@@ -296,7 +292,7 @@ describe("Core: Middleware", () => {
         },
       });
 
-      const response = await specHelper.runAction("randomNumber");
+      const response = await specHelper.runAction<any>("randomNumber");
       expect(response._processorNoteFirst).toEqual("first");
       expect(response._processorNoteSecond).toEqual("second");
     });
@@ -310,7 +306,7 @@ describe("Core: Middleware", () => {
         },
       });
 
-      const { randomNumber, error } = await specHelper.runAction(
+      const { randomNumber, error } = await specHelper.runAction<any>(
         "randomNumber"
       );
       expect(error).toEqual("Error: BLOCKED");

--- a/__tests__/core/plugins.ts
+++ b/__tests__/core/plugins.ts
@@ -40,7 +40,7 @@ describe("Core: Plugins", () => {
     });
 
     test("can load an action from a plugin", async () => {
-      const response = await specHelper.runAction("pluginAction");
+      const response = await specHelper.runAction<any>("pluginAction");
       expect(response.error).toBeUndefined();
       expect(response.cool).toEqual(true);
     });

--- a/__tests__/core/specHelper.ts
+++ b/__tests__/core/specHelper.ts
@@ -1,17 +1,17 @@
 import { api, Process, specHelper, task } from "./../../src/index";
+import { RandomNumber } from "../../src/actions/randomNumber";
+import { SleepTest } from "../../src/actions/sleepTest";
 
 const actionhero = new Process();
 
 describe("Core: specHelper", () => {
-  beforeAll(async () => {
-    await actionhero.start();
-  });
-  afterAll(async () => {
-    await actionhero.stop();
-  });
+  beforeAll(async () => await actionhero.start());
+  afterAll(async () => await actionhero.stop());
 
   test("can make a request with just params", async () => {
-    const { randomNumber } = await specHelper.runAction("randomNumber");
+    const { randomNumber } = await specHelper.runAction<RandomNumber>(
+      "randomNumber"
+    );
     expect(randomNumber).toBeGreaterThanOrEqual(0);
     expect(randomNumber).toBeLessThan(1);
   });
@@ -102,7 +102,9 @@ describe("Core: specHelper", () => {
 
     describe("happy-path", () => {
       test("if the response payload is an object, it appends metadata", async () => {
-        const response = await specHelper.runAction("randomNumber");
+        const response = await specHelper.runAction<RandomNumber>(
+          "randomNumber"
+        );
         expect(response.error).toBeUndefined();
         expect(response.randomNumber).toBeTruthy();
         expect(response.messageId).toBeTruthy();
@@ -138,7 +140,9 @@ describe("Core: specHelper", () => {
       });
 
       test("if the response payload is an object, it should not append metadata", async () => {
-        const response = await specHelper.runAction("randomNumber");
+        const response = await specHelper.runAction<RandomNumber>(
+          "randomNumber"
+        );
         expect(response.error).toBeUndefined();
         expect(response.randomNumber).toBeTruthy();
         expect(response.messageId).toBeUndefined();
@@ -178,8 +182,9 @@ describe("Core: specHelper", () => {
 
   describe("test responses", () => {
     test("will not report a broken test as a broken action (sync)", async () => {
-      const response = await specHelper.runAction("randomNumber");
+      const response = await specHelper.runAction<RandomNumber>("randomNumber");
       try {
+        //@ts-ignore
         response.not.a.real.thing();
         throw new Error("should not get here");
       } catch (e) {
@@ -190,8 +195,9 @@ describe("Core: specHelper", () => {
     });
 
     test("will not report a broken test as a broken action (async)", async () => {
-      const response = await specHelper.runAction("sleepTest");
+      const response = await specHelper.runAction<SleepTest>("sleepTest");
       try {
+        //@ts-ignore
         response.not.a.real.thing();
         throw new Error("should not get here");
       } catch (e) {

--- a/__tests__/integration/ioredis-mock.ts
+++ b/__tests__/integration/ioredis-mock.ts
@@ -70,9 +70,7 @@ describe("with ioredis-mock", () => {
     await api.redis.clients.client.flushdb();
   });
 
-  afterAll(async () => {
-    await actionhero.stop();
-  });
+  afterAll(async () => await actionhero.stop());
 
   test("basic redis operations work and data is shared between the connections", async () => {
     await api.redis.clients.client.set("__test", "abc");

--- a/__tests__/integration/sendBuffer.ts
+++ b/__tests__/integration/sendBuffer.ts
@@ -12,9 +12,7 @@ describe("Server: sendBuffer", () => {
     url = "http://localhost:" + config.servers.web.port;
   });
 
-  afterAll(async () => {
-    await actionhero.stop();
-  });
+  afterAll(async () => await actionhero.stop());
 
   beforeAll(() => {
     api.actions.versions.sendBufferTest = [1];

--- a/__tests__/integration/sendFile.ts
+++ b/__tests__/integration/sendFile.ts
@@ -12,9 +12,7 @@ describe("Server: sendFile", () => {
     url = "http://localhost:" + config.servers.web.port;
   });
 
-  afterAll(async () => {
-    await actionhero.stop();
-  });
+  afterAll(async () => await actionhero.stop());
 
   test("Server should sendFile", async () => {
     const stats = fs.statSync(__dirname + "/../../public/logo/actionhero.png");

--- a/__tests__/integration/sharedFingerprint.ts
+++ b/__tests__/integration/sharedFingerprint.ts
@@ -45,9 +45,7 @@ describe("Integration: Web Server + Websocket Socket shared fingerprint", () => 
     ); // eslint-disable-line
   });
 
-  afterAll(async () => {
-    await actionhero.stop();
-  });
+  afterAll(async () => await actionhero.stop());
 
   test("should exist when web server been called", async () => {
     const body = await request.get({

--- a/__tests__/servers/web/allowedRequestHosts.ts
+++ b/__tests__/servers/web/allowedRequestHosts.ts
@@ -38,9 +38,7 @@ describe("Server: Web", () => {
     url = "http://localhost:" + config.servers.web.port;
   });
 
-  afterAll(async () => {
-    await actionhero.stop();
-  });
+  afterAll(async () => await actionhero.stop());
 
   describe("request redirection (allowedRequestHosts)", () => {
     test("will redirect clients if they do not request the proper host", async () => {

--- a/__tests__/servers/web/jsonp.ts
+++ b/__tests__/servers/web/jsonp.ts
@@ -37,9 +37,7 @@ describe("Server: Web", () => {
     url = "http://localhost:" + config.servers.web.port;
   });
 
-  afterAll(async () => {
-    await actionhero.stop();
-  });
+  afterAll(async () => await actionhero.stop());
 
   describe("JSONp", () => {
     test("can ask for JSONp responses", async () => {

--- a/__tests__/servers/web/rawBody.ts
+++ b/__tests__/servers/web/rawBody.ts
@@ -47,9 +47,7 @@ describe("Server: Web", () => {
     url = "http://localhost:" + config.servers.web.port;
   });
 
-  afterAll(async () => {
-    await actionhero.stop();
-  });
+  afterAll(async () => await actionhero.stop());
 
   describe("connection.rawConnection.rawBody", () => {
     beforeAll(() => {

--- a/__tests__/servers/web/returnErrorCodes.ts
+++ b/__tests__/servers/web/returnErrorCodes.ts
@@ -45,9 +45,7 @@ describe("Server: Web", () => {
     url = "http://localhost:" + config.servers.web.port;
   });
 
-  afterAll(async () => {
-    await actionhero.stop();
-  });
+  afterAll(async () => await actionhero.stop());
 
   describe("errorCodes", () => {
     test("returnErrorCodes false should still have a status of 200", async () => {

--- a/__tests__/servers/web/routes/routes.ts
+++ b/__tests__/servers/web/routes/routes.ts
@@ -22,9 +22,7 @@ describe("Server: Web", () => {
     url = "http://localhost:" + config.servers.web.port;
   });
 
-  afterAll(async () => {
-    await actionhero.stop();
-  });
+  afterAll(async () => await actionhero.stop());
 
   describe("routes", () => {
     let originalRoutes;

--- a/__tests__/servers/web/web.ts
+++ b/__tests__/servers/web/web.ts
@@ -22,9 +22,7 @@ describe("Server: Web", () => {
     url = "http://localhost:" + config.servers.web.port;
   });
 
-  afterAll(async () => {
-    await actionhero.stop();
-  });
+  afterAll(async () => await actionhero.stop());
 
   test("should be up and return data", async () => {
     await request.get(url + "/api/randomNumber").then(toJson);

--- a/__tests__/servers/websocket.ts
+++ b/__tests__/servers/websocket.ts
@@ -91,9 +91,7 @@ describe("Server: Web Socket", () => {
     await connectClients();
   });
 
-  afterAll(async () => {
-    await actionhero.stop();
-  });
+  afterAll(async () => await actionhero.stop());
 
   test("socket client connections should work: client 1", async () => {
     const data = await awaitMethod(clientA, "connect", true);

--- a/__tests__/tasks/runAction.ts
+++ b/__tests__/tasks/runAction.ts
@@ -2,30 +2,21 @@ import { Process, specHelper } from "./../../src/index";
 import { RunAction } from "../../src/tasks/runAction";
 
 describe("Test: RunAction", () => {
-  const RunMethod = RunAction.prototype.run;
   const actionhero = new Process();
 
-  beforeAll(async () => {
-    await actionhero.start();
-  });
-
-  afterAll(async () => {
-    await actionhero.stop();
-  });
+  beforeAll(async () => await actionhero.start());
+  afterAll(async () => await actionhero.stop());
 
   test("can run the task without params", async () => {
-    const { randomNumber } = await specHelper.runTask<typeof RunMethod>(
-      "runAction",
-      {
-        action: "randomNumber",
-      }
-    );
+    const { randomNumber } = await specHelper.runTask<RunAction>("runAction", {
+      action: "randomNumber",
+    });
     expect(randomNumber).toBeGreaterThanOrEqual(0);
     expect(randomNumber).toBeLessThan(1);
   });
 
   test("can run the task with params", async () => {
-    const { cacheTestResults } = await specHelper.runTask<typeof RunMethod>(
+    const { cacheTestResults } = await specHelper.runTask<RunAction>(
       "runAction",
       {
         action: "cacheTest",
@@ -38,7 +29,7 @@ describe("Test: RunAction", () => {
 
   test("will throw with errors", async () => {
     await expect(
-      specHelper.runTask<typeof RunMethod>("runAction", {
+      specHelper.runTask<RunAction>("runAction", {
         action: "cacheTest",
       })
     ).rejects.toThrow(/key is a required parameter for this action/);

--- a/__tests__/tasks/runAction.ts
+++ b/__tests__/tasks/runAction.ts
@@ -1,10 +1,10 @@
 import { Process, specHelper } from "./../../src/index";
 import { RunAction } from "../../src/tasks/runAction";
 
-const RunMethod = RunAction.prototype.run;
-const actionhero = new Process();
-
 describe("Test: RunAction", () => {
+  const RunMethod = RunAction.prototype.run;
+  const actionhero = new Process();
+
   beforeAll(async () => {
     await actionhero.start();
   });

--- a/__tests__/template.ts.example
+++ b/__tests__/template.ts.example
@@ -3,6 +3,7 @@ import { Status } from "../../src/actions/status";
 
 describe("actionhero Tests", () => {
   const actionhero = new Process();
+  const RunMethod = Status.prototype.run;
 
   beforeAll(async () => {
     await actionhero.start();
@@ -19,7 +20,6 @@ describe("actionhero Tests", () => {
   });
 
   test("can retrieve server uptime via the status action", async () => {
-    const RunMethod = Status.prototype.run;
     const { uptime } = await specHelper.runAction<RunMethod>("status");
     expect(uptime).toBeGreaterThan(0);
   });

--- a/__tests__/template.ts.example
+++ b/__tests__/template.ts.example
@@ -1,5 +1,5 @@
 import { Process, env, id, specHelper } from "actionhero";
-import { StatusActions } from "../../src/actions/status";
+import { Status } from "../../src/actions/status";
 
 describe("actionhero Tests", () => {
   const actionhero = new Process();
@@ -19,7 +19,7 @@ describe("actionhero Tests", () => {
   });
 
   test("can retrieve server uptime via the status action", async () => {
-    const RunMethod = StatusActions.prototype.run;
+    const RunMethod = Status.prototype.run;
     const { uptime } = await specHelper.runAction<RunMethod>("status");
     expect(uptime).toBeGreaterThan(0);
   });

--- a/__tests__/template.ts.example
+++ b/__tests__/template.ts.example
@@ -1,10 +1,11 @@
 import { Process, env, id, specHelper } from "actionhero";
-const actionhero = new Process();
-let api;
+import { StatusActions } from "../../src/actions/status";
 
 describe("actionhero Tests", () => {
+  const actionhero = new Process();
+
   beforeAll(async () => {
-    api = await actionhero.start();
+    await actionhero.start();
   });
 
   afterAll(async () => {
@@ -18,7 +19,8 @@ describe("actionhero Tests", () => {
   });
 
   test("can retrieve server uptime via the status action", async () => {
-    const { uptime } = await specHelper.runAction("status");
+    const RunMethod = StatusActions.prototype.run;
+    const { uptime } = await specHelper.runAction<RunMethod>("status");
     expect(uptime).toBeGreaterThan(0);
   });
 });

--- a/__tests__/template.ts.example
+++ b/__tests__/template.ts.example
@@ -3,15 +3,9 @@ import { Status } from "../../src/actions/status";
 
 describe("actionhero Tests", () => {
   const actionhero = new Process();
-  const RunMethod = Status.prototype.run;
 
-  beforeAll(async () => {
-    await actionhero.start();
-  });
-
-  afterAll(async () => {
-    await actionhero.stop();
-  });
+  beforeAll(async () => await actionhero.start());
+  afterAll(async () => await actionhero.stop());
 
   test("should have booted into the test env", () => {
     expect(process.env.NODE_ENV).toEqual("test");
@@ -20,7 +14,7 @@ describe("actionhero Tests", () => {
   });
 
   test("can retrieve server uptime via the status action", async () => {
-    const { uptime } = await specHelper.runAction<RunMethod>("status");
+    const { uptime } = await specHelper.runAction<Status>("status");
     expect(uptime).toBeGreaterThan(0);
   });
 });

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "actionhero": "dist/bin/actionhero.js"
   },
   "jest": {
+    "maxWorkers": "50%",
     "testPathIgnorePatterns": [
       "<rootDir>/__tests__/testPlugin",
       "<rootDir>/tmp"
@@ -86,7 +87,7 @@
   },
   "scripts": {
     "postinstall": "echo 'To generate a new actionhero project, run \"npx actionhero generate\"'",
-    "test": "jest --maxWorkers 50%",
+    "test": "jest",
     "prepare": "npm run build && npm run docs",
     "pretest": "npm run lint && npm run build",
     "dev": "ts-node-dev --transpile-only --no-deps ./src/server",

--- a/src/actions/status.ts
+++ b/src/actions/status.ts
@@ -63,9 +63,9 @@ export class Status extends Action {
     return {
       id: id,
       actionheroVersion: actionheroVersion,
-      name: packageJSON.name,
-      description: packageJSON.description,
-      version: packageJSON.version,
+      name: packageJSON.name as string,
+      description: packageJSON.description as string,
+      version: packageJSON.version as string,
       uptime: new Date().getTime() - api.bootTime,
       consumedMemoryMB,
       resqueTotalQueueLength,

--- a/src/actions/status.ts
+++ b/src/actions/status.ts
@@ -2,6 +2,10 @@ import { api, id, task, Action, actionheroVersion } from "./../index";
 import * as path from "path";
 import * as fs from "fs";
 
+// These values are probably good starting points, but you should expect to tweak them for your application
+const maxMemoryAlloted = process.env.maxMemoryAlloted || 500;
+const maxResqueQueueLength = process.env.maxResqueQueueLength || 1000;
+
 const packageJSON = JSON.parse(
   fs
     .readFileSync(
@@ -10,9 +14,6 @@ const packageJSON = JSON.parse(
     .toString()
 );
 
-// These values are probably good starting points, but you should expect to tweak them for your application
-const maxMemoryAlloted = process.env.maxMemoryAlloted || 500;
-const maxResqueQueueLength = process.env.maxResqueQueueLength || 1000;
 export class Status extends Action {
   constructor() {
     super();

--- a/src/actions/swagger.ts
+++ b/src/actions/swagger.ts
@@ -140,11 +140,11 @@ export class Swagger extends Action {
         title: parentPackageJSON.name,
         license: { name: parentPackageJSON.license },
       },
-      host: config.servers.web.allowedRequestHosts[0]
+      host: (config.servers.web.allowedRequestHosts[0]
         ? config.servers.web.allowedRequestHosts[0]
             .replace("https://", "")
             .replace("http://", "")
-        : `localhost:${config.servers.web.port}`,
+        : `localhost:${config.servers.web.port}`) as string,
       basePath: `/api/${API_VERSION}`,
       // tags: tags.map((tag) => {
       //   return { name: tag, description: `topic: ${tag}` };

--- a/src/modules/specHelper.ts
+++ b/src/modules/specHelper.ts
@@ -33,7 +33,7 @@ export namespace specHelper {
     const response: (ActionRunMethod extends Action["run"]
       ? UnwrapPromise<ActionRunMethod>
       : any) & {
-      error: string;
+      error: Error | string;
     } = await new Promise((resolve) => {
       api.servers.servers.testServer.processAction(connection);
       connection.actionCallbacks[connection.messageId] = resolve;
@@ -73,7 +73,7 @@ export namespace specHelper {
     const result: (TaskRunMethod extends Task["run"]
       ? UnwrapPromise<TaskRunMethod>
       : any) & {
-      error: string;
+      error: Error | string;
     } = await api.tasks.tasks[taskName].run(params, undefined);
     return result;
   }

--- a/src/servers/web.ts
+++ b/src/servers/web.ts
@@ -475,13 +475,9 @@ export class WebServer extends Server {
       this.config.metadataOptions.serverInformation &&
       typeof data.response !== "string"
     ) {
-      const stopTime = new Date().getTime();
-      data.response.serverInformation = {
-        serverName: config.general.serverName,
-        apiVersion: config.general.apiVersion,
-        requestDuration: stopTime - data.connection.connectedAt,
-        currentTime: stopTime,
-      };
+      data.response.serverInformation = this.buildServerInformation(
+        data.connection.connectedAt
+      );
     }
 
     if (
@@ -789,13 +785,23 @@ export class WebServer extends Server {
     }, {});
   }
 
+  buildServerInformation(connectedAt: number) {
+    const stopTime = new Date().getTime();
+    return {
+      serverName: config.general.serverName,
+      apiVersion: config.general.apiVersion,
+      requestDuration: stopTime - connectedAt,
+      currentTime: stopTime,
+    };
+  }
+
   buildRequesterInformation(connection) {
     const requesterInformation = {
       id: connection.id,
       fingerprint: connection.fingerprint,
       messageId: connection.messageId,
       remoteIP: connection.remoteIP,
-      receivedParams: {},
+      receivedParams: {} as { [key: string]: any },
     };
 
     for (const p in connection.params) {

--- a/templates/test/action.ts.template
+++ b/templates/test/action.ts.template
@@ -1,19 +1,18 @@
 import { Process, specHelper } from "actionhero";
-const actionhero = new Process();
 
-describe("Action", () => {
-  describe("%%name%%", () => {
-    beforeAll(async () => {
-      await actionhero.start();
-    });
+describe("Action: %%name%%", () => {
+  const actionhero = new Process();
 
-    afterAll(async () => {
-      await actionhero.stop();
-    });
+  beforeAll(async () => {
+    await actionhero.start();
+  });
 
-    test("returns OK", async () => {
-      const { ok } = await specHelper.runAction("%%name%%");
-      expect(ok).toEqual(true);
-    });
+  afterAll(async () => {
+    await actionhero.stop();
+  });
+
+  test("returns OK", async () => {
+    const { ok } = await specHelper.runAction("%%name%%");
+    expect(ok).toEqual(true);
   });
 });

--- a/templates/test/action.ts.template
+++ b/templates/test/action.ts.template
@@ -3,13 +3,8 @@ import { Process, specHelper } from "actionhero";
 describe("Action: %%name%%", () => {
   const actionhero = new Process();
 
-  beforeAll(async () => {
-    await actionhero.start();
-  });
-
-  afterAll(async () => {
-    await actionhero.stop();
-  });
+  beforeAll(async () => await actionhero.start());
+  afterAll(async () => await actionhero.stop());
 
   test("returns OK", async () => {
     const { ok } = await specHelper.runAction("%%name%%");

--- a/templates/test/task.ts.template
+++ b/templates/test/task.ts.template
@@ -3,13 +3,8 @@ import { Process, task, api, specHelper } from "actionhero";
 describe("Task: %%name%%", () => {
   const actionhero = new Process();
 
-  beforeAll(async () => {
-    await actionhero.start();
-  });
-
-  afterAll(async () => {
-    await actionhero.stop();
-  });
+  beforeAll(async () => await actionhero.start());
+  afterAll(async () => await actionhero.stop());
 
   beforeEach(async () => {
     await api.resque.queue.connection.redis.flushdb();

--- a/templates/test/task.ts.template
+++ b/templates/test/task.ts.template
@@ -1,25 +1,25 @@
 import { Process, task, api, specHelper } from "actionhero";
-const actionhero = new Process();
 
-describe("Task", () => {
-  describe("%%name%%", () => {
-    beforeAll(async () => {
-      await actionhero.start();
-    });
+describe("Task: %%name%%", () => {
+  const actionhero = new Process();
 
-    afterAll(async () => {
-      await actionhero.stop();
-    });
+  beforeAll(async () => {
+    await actionhero.start();
+  });
 
-    beforeEach(async () => {
-      await api.resque.queue.connection.redis.flushdb();
-    });
+  afterAll(async () => {
+    await actionhero.stop();
+  });
 
-    test("can be enqueued", async () => {
-      await task.enqueue("%%name%%", {});
-      const found = await specHelper.findEnqueuedTasks("%%name%%");
-      expect(found.length).toEqual(1);
-      expect(found[0].timestamp).toBeNull();
-    });
+  beforeEach(async () => {
+    await api.resque.queue.connection.redis.flushdb();
+  });
+
+  test("can be enqueued", async () => {
+    await task.enqueue("%%name%%", {});
+    const found = await specHelper.findEnqueuedTasks("%%name%%");
+    expect(found.length).toEqual(1);
+    expect(found[0].timestamp).toBeNull();
   });
 });
+


### PR DESCRIPTION
(Breaking Change)

It's now much easier to get the types of your response from `specHelper.runAction<Action>()` and `specHelper.runTask<Task>()`!

Just provide your Action or Task Class!

```ts
import { Process, specHelper } from "./../../src/index";
import { RandomNumber } from "../../src/actions/randomNumber";

describe("Action: randomNumber", () => {
  const actionhero = new Process();
  beforeAll(async () => await actionhero.start());
  afterAll(async () => await actionhero.stop());

  let firstNumber = null;

  test("generates random numbers", async () => {
    const { randomNumber } = await specHelper.runAction<RandomNumber>(
      "randomNumber"
    );
    expect(randomNumber).toBeGreaterThan(0);
    expect(randomNumber).toBeLessThan(1);
    firstNumber = randomNumber;
  });

  test("is unique / random", async () => {
    const { randomNumber } = await specHelper.runAction<RandomNumber>(
      "randomNumber"
    );
    expect(randomNumber).toBeGreaterThan(0);
    expect(randomNumber).toBeLessThan(1);
    expect(randomNumber).not.toEqual(firstNumber);
  });
});

```