### PR TITLE
Implement `task.delByFunction()`

### DIFF
--- a/__tests__/core/tasks/tasks.ts
+++ b/__tests__/core/tasks/tasks.ts
@@ -365,6 +365,17 @@ describe("Core: Tasks", () => {
     expect(lengthAgain).toEqual(0);
   });
 
+  test("I can remove enqueued jobs by name", async () => {
+    await task.enqueue("regularTask", { word: "first" });
+    const length = await api.resque.queue.length(queue);
+    expect(length).toEqual(1);
+
+    await task.delByFunction(queue, "regularTask");
+
+    const lengthAgain = await api.resque.queue.length(queue);
+    expect(lengthAgain).toEqual(0);
+  });
+
   test("I can remove a delayed job", async () => {
     await task.enqueueIn(1000, "regularTask", { word: "first" });
     const timestamps = await api.resque.queue.scheduledAt(

--- a/src/modules/task.ts
+++ b/src/modules/task.ts
@@ -135,6 +135,26 @@ export namespace task {
   }
 
   /**
+   * * will delete all jobs in the given queue of the named function/class
+   * * will not prevent new jobs from being added as this method is running
+   * * will not delete jobs in the delayed queues
+   *
+   * Inputs:
+   * * q: Which queue/priority is to run on?
+   * * taskName: The name of the job, likely to be the same name as a tak.
+   * * start? - starting position of task count to remove
+   * * stop? - stop position of task count to remove
+   */
+  export async function delByFunction(
+    q: string,
+    taskName: string,
+    start?: number,
+    stop?: number
+  ) {
+    return api.resque.queue.delByFunction(q, taskName, start, stop);
+  }
+
+  /**
    * Delete all previously enqueued tasks, which haven't been run yet, from all possible delayed timestamps.
    * Will throw an error if redis cannot be reached.
    *


### PR DESCRIPTION
Hoist `api.resque.queue.delByFunction` to `task.delByFunction`

Closes https://github.com/actionhero/actionhero/issues/1784