### PR TITLE
Support loading task as default file export

### DIFF
--- a/src/initializers/tasks.ts
+++ b/src/initializers/tasks.ts
@@ -39,6 +39,9 @@ export class Tasks extends Initializer {
     api.tasks.loadFile = async (fullFilePath: string, reload = false) => {
       let task;
       let collection = await import(fullFilePath);
+      if (typeof collection === "function") {
+        collection = [collection];
+      }
       for (const i in collection) {
         const TaskClass = collection[i];
         task = new TaskClass();


### PR DESCRIPTION
Closes https://github.com/actionhero/actionhero/issues/1817

```ts
import { Task } from "actionhero";

export default class RunAction extends Task { // <--- Now the "default" export works too
  constructor() {
    super();
    this.name = "myTask";
    this.description = "I am a test task";
    this.frequency = 0;
    this.queue = "default";
  }

  async run(params) {
    console.log("Hello from task");
  }
}
```
