### PR TITLE
Added types for the loglevel

### DIFF
--- a/src/classes/action.ts
+++ b/src/classes/action.ts
@@ -1,5 +1,6 @@
-import { Inputs } from "./inputs";
 import { api } from "../index";
+import type { LogLevels } from "../modules/log";
+import { Inputs } from "./inputs";
 
 /**
  * Create a new Actionhero Action. The required properties of an action. These can be defined statically (this.name) or as methods which return a value.
@@ -35,7 +36,7 @@ export abstract class Action {
   /**Are there connections from any servers which cannot use this Action (default: [])? */
   blockedConnectionTypes?: Array<string>;
   /**Under what level should connections to this Action be logged (default 'info')? */
-  logLevel?: string;
+  logLevel?: LogLevels;
   /**If this Action is responding to a `web` request, and that request has a file extension like *.jpg, should Actionhero set the response headers to match that extension (default: true)? */
   matchExtensionMimeType?: boolean;
   /**Should this Action appear in api.documentation.documentation? (default: true)? */

--- a/src/classes/actionProcessor.ts
+++ b/src/classes/actionProcessor.ts
@@ -1,10 +1,10 @@
-import { Connection } from "./connection";
-import { Action } from "./action";
-import { config } from "./../modules/config";
-import { log } from "../modules/log";
-import { utils } from "../modules/utils";
 import * as dotProp from "dot-prop";
 import { api } from "../index";
+import { log, LogLevels } from "../modules/log";
+import { utils } from "../modules/utils";
+import { config } from "./../modules/config";
+import { Action } from "./action";
+import { Connection } from "./connection";
 
 export enum ActionsStatus {
   Complete,
@@ -126,7 +126,7 @@ export class ActionProcessor<ActionClass extends Action> {
   private logAndReportAction(status: ActionsStatus, error: Error) {
     const { type, rawConnection } = this.connection;
 
-    let logLevel = "info";
+    let logLevel: LogLevels = "info";
     if (this.actionTemplate && this.actionTemplate.logLevel) {
       logLevel = this.actionTemplate.logLevel;
     }

--- a/src/classes/exceptionReporter.ts
+++ b/src/classes/exceptionReporter.ts
@@ -1,7 +1,9 @@
+import type { LogLevels } from "../modules/log";
+
 export type ExceptionReporter = (
   error: Error,
   type: string,
   name: string,
   objects?: any,
-  severity?: string
+  severity?: LogLevels
 ) => void;

--- a/src/classes/server.ts
+++ b/src/classes/server.ts
@@ -1,8 +1,8 @@
 import { EventEmitter } from "events";
-import { Connection } from "./connection";
-import { ActionProcessor } from "./actionProcessor";
 import { api, config } from "../index";
-import { log } from "../modules/log";
+import { log, LogLevels } from "../modules/log";
+import { ActionProcessor } from "./actionProcessor";
+import { Connection } from "./connection";
 
 interface ServerConfig {
   [key: string]: any;
@@ -264,7 +264,7 @@ export abstract class Server extends EventEmitter {
   /**
    * Log a message from this server type.  A wrapper around log() with a server prefix.
    */
-  log(message: string, severity?: string, data?: any) {
+  log(message: string, severity?: LogLevels, data?: any) {
     log(`[server: ${this.type}] ${message}`, severity, data);
   }
 }

--- a/src/modules/log.ts
+++ b/src/modules/log.ts
@@ -20,6 +20,16 @@ loggers = config.logger.loggers.map((loggerBuilder: Function) => {
   return winston.createLogger(resolvedLogger);
 });
 
+export type LogLevels =
+  | "emerg"
+  | "alert"
+  | "crit"
+  | "error"
+  | "warning"
+  | "notice"
+  | "info"
+  | "debug";
+
 /**
  * Log a message, with optional metadata.  The message can be logged to a number of locations (stdio, files, etc) as configured via config/logger.js
  *
@@ -31,7 +41,7 @@ loggers = config.logger.loggers.map((loggerBuilder: Function) => {
  * Logging levels in winston conform to the severity ordering specified by RFC5424: severity of all levels is assumed to be numerically ascending from most important to least important.
  * Learn more at https://github.com/winstonjs/winston
  */
-export function log(message: string, severity: string = "info", data?: any) {
+export function log(message: string, severity: LogLevels = "info", data?: any) {
   loggers.map((logger) => {
     if (logger.levels[severity] === undefined) {
       severity = "info";


### PR DESCRIPTION
This may be a breaking change.
If the types include `string` then we no longer get the typescript autocomplete.