### PR TITLE
Rename `LogLevels` to `ActionheroLogLevel` and export

### DIFF
--- a/src/classes/action.ts
+++ b/src/classes/action.ts
@@ -1,5 +1,5 @@
 import { api } from "../index";
-import type { LogLevels } from "../modules/log";
+import type { ActionheroLogLevel } from "../modules/log";
 import { Inputs } from "./inputs";
 
 /**
@@ -36,7 +36,7 @@ export abstract class Action {
   /**Are there connections from any servers which cannot use this Action (default: [])? */
   blockedConnectionTypes?: Array<string>;
   /**Under what level should connections to this Action be logged (default 'info')? */
-  logLevel?: LogLevels;
+  logLevel?: ActionheroLogLevel;
   /**If this Action is responding to a `web` request, and that request has a file extension like *.jpg, should Actionhero set the response headers to match that extension (default: true)? */
   matchExtensionMimeType?: boolean;
   /**Should this Action appear in api.documentation.documentation? (default: true)? */

--- a/src/classes/actionProcessor.ts
+++ b/src/classes/actionProcessor.ts
@@ -1,6 +1,6 @@
 import * as dotProp from "dot-prop";
 import { api } from "../index";
-import { log, LogLevels } from "../modules/log";
+import { log, ActionheroLogLevel } from "../modules/log";
 import { utils } from "../modules/utils";
 import { config } from "./../modules/config";
 import { Action } from "./action";
@@ -126,7 +126,7 @@ export class ActionProcessor<ActionClass extends Action> {
   private logAndReportAction(status: ActionsStatus, error: Error) {
     const { type, rawConnection } = this.connection;
 
-    let logLevel: LogLevels = "info";
+    let logLevel: ActionheroLogLevel = "info";
     if (this.actionTemplate && this.actionTemplate.logLevel) {
       logLevel = this.actionTemplate.logLevel;
     }

--- a/src/classes/exceptionReporter.ts
+++ b/src/classes/exceptionReporter.ts
@@ -1,9 +1,9 @@
-import type { LogLevels } from "../modules/log";
+import type { ActionheroLogLevel } from "../modules/log";
 
 export type ExceptionReporter = (
   error: Error,
   type: string,
   name: string,
   objects?: any,
-  severity?: LogLevels
+  severity?: ActionheroLogLevel
 ) => void;

--- a/src/classes/server.ts
+++ b/src/classes/server.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "events";
 import { api, config } from "../index";
-import { log, LogLevels } from "../modules/log";
+import { log, ActionheroLogLevel } from "../modules/log";
 import { ActionProcessor } from "./actionProcessor";
 import { Connection } from "./connection";
 
@@ -264,7 +264,7 @@ export abstract class Server extends EventEmitter {
   /**
    * Log a message from this server type.  A wrapper around log() with a server prefix.
    */
-  log(message: string, severity?: LogLevels, data?: any) {
+  log(message: string, severity?: ActionheroLogLevel, data?: any) {
     log(`[server: ${this.type}] ${message}`, severity, data);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ export { ActionProcessor } from "./classes/actionProcessor";
 // export modules (lower case)
 export { utils } from "./modules/utils";
 export { config } from "./modules/config";
-export { log, loggers } from "./modules/log";
+export { log, loggers, ActionheroLogLevel } from "./modules/log";
 export { action } from "./modules/action";
 export { task } from "./modules/task";
 export { cache } from "./modules/cache";

--- a/src/modules/log.ts
+++ b/src/modules/log.ts
@@ -20,7 +20,7 @@ loggers = config.logger.loggers.map((loggerBuilder: Function) => {
   return winston.createLogger(resolvedLogger);
 });
 
-export type LogLevels =
+export type ActionheroLogLevel =
   | "emerg"
   | "alert"
   | "crit"
@@ -41,7 +41,11 @@ export type LogLevels =
  * Logging levels in winston conform to the severity ordering specified by RFC5424: severity of all levels is assumed to be numerically ascending from most important to least important.
  * Learn more at https://github.com/winstonjs/winston
  */
-export function log(message: string, severity: LogLevels = "info", data?: any) {
+export function log(
+  message: string,
+  severity: ActionheroLogLevel = "info",
+  data?: any
+) {
   loggers.map((logger) => {
     if (logger.levels[severity] === undefined) {
       severity = "info";


### PR DESCRIPTION
`ActionheroLogLevel` needs to be exported so consumers can type their logs