### PR TITLE
Fix the storage and retrival of chatRoom member details

### DIFF
--- a/__tests__/core/chatRoom.ts
+++ b/__tests__/core/chatRoom.ts
@@ -240,6 +240,32 @@ describe("Core", () => {
         await chatRoom.destroy("newRoom");
       });
 
+      test("can see the details of the other members in the room", async () => {
+        const client = await specHelper.buildConnection();
+        const otherClient = await specHelper.buildConnection();
+        await chatRoom.add("newRoom");
+        await chatRoom.addMember(client.id, "newRoom");
+        await utils.sleep(100);
+        await chatRoom.addMember(otherClient.id, "newRoom");
+
+        const { members, membersCount } = await chatRoom.roomStatus("newRoom");
+        expect(membersCount).toBe(2);
+        expect(members).toEqual({
+          [client.id]: { id: client.id, joinedAt: expect.any(Number) },
+          [otherClient.id]: {
+            id: otherClient.id,
+            joinedAt: expect.any(Number),
+          },
+        });
+        expect(members[otherClient.id].joinedAt).toBeGreaterThan(
+          members[client.id].joinedAt
+        );
+
+        client.destroy();
+        otherClient.destroy();
+        await chatRoom.destroy("newRoom");
+      });
+
       describe("chat middleware", () => {
         let clientA;
         let clientB;

--- a/src/modules/chatRoom.ts
+++ b/src/modules/chatRoom.ts
@@ -1,5 +1,6 @@
 import { api, config, id, redis, Connection } from "./../index";
 import * as RedisModule from "../modules/redis";
+import { UnwrapPromise } from "./tsUtils";
 
 export namespace chatRoom {
   /**
@@ -165,9 +166,11 @@ export namespace chatRoom {
    * Learn about the connections in the room.
    * Returns a hash of the form { room: room, members: cleanedMembers, membersCount: count }.  Members is an array of connections in the room sanitized via `api.chatRoom.sanitizeMemberDetails`
    */
-  export async function roomStatus(
-    room: string
-  ): Promise<{ [key: string]: any }> {
+  export async function roomStatus(room: string): Promise<{
+    room: string;
+    membersCount: number;
+    members: Record<string, UnwrapPromise<typeof sanitizeMemberDetails>>;
+  }> {
     if (room) {
       const found = await chatRoom.exists(room);
       if (found === true) {
@@ -180,7 +183,7 @@ export namespace chatRoom {
 
         for (const id in members) {
           const data = JSON.parse(members[id]);
-          cleanedMembers[id] = chatRoom.sanitizeMemberDetails(data);
+          cleanedMembers[id] = await chatRoom.sanitizeMemberDetails(data);
           count++;
         }
 
@@ -243,7 +246,7 @@ export namespace chatRoom {
     }
 
     if (connection.rooms.indexOf(room) < 0) {
-      const memberDetails = chatRoom.generateMemberDetails(connection);
+      const memberDetails = await chatRoom.generateMemberDetails(connection);
       connection.rooms.push(room);
       await client().hset(
         api.chatRoom.keys.members + room,

--- a/src/modules/chatRoom.ts
+++ b/src/modules/chatRoom.ts
@@ -228,26 +228,25 @@ export namespace chatRoom {
       );
     }
 
-    if (connection.rooms.indexOf(room) >= 0) {
+    if (connection.rooms.includes(room)) {
       throw new Error(
         await config.errors.connectionAlreadyInRoom(connection, room)
       );
     }
 
-    if (connection.rooms.indexOf(room) < 0) {
+    if (!connection.rooms.includes(room)) {
       const found = await chatRoom.exists(room);
       if (!found) {
         throw new Error(await config.errors.connectionRoomNotExist(room));
       }
-    }
 
-    if (connection.rooms.indexOf(room) < 0) {
       await api.chatRoom.runMiddleware(connection, room, "join");
-    }
 
-    if (connection.rooms.indexOf(room) < 0) {
+      if (!connection.rooms.includes(room)) {
+        connection.rooms.push(room);
+      }
+
       const memberDetails = await chatRoom.generateMemberDetails(connection);
-      connection.rooms.push(room);
       await client().hset(
         api.chatRoom.keys.members + room,
         connection.id,
@@ -277,26 +276,25 @@ export namespace chatRoom {
       );
     }
 
-    if (connection.rooms.indexOf(room) < 0) {
+    if (!connection.rooms.includes(room)) {
       throw new Error(
         await config.errors.connectionNotInRoom(connection, room)
       );
     }
 
-    if (connection.rooms.indexOf(room) >= 0) {
+    if (connection.rooms.includes(room)) {
       const found = await chatRoom.exists(room);
       if (!found) {
         throw new Error(await config.errors.connectionRoomNotExist(room));
       }
-    }
 
-    if (connection.rooms.indexOf(room) >= 0) {
       await api.chatRoom.runMiddleware(connection, room, "leave");
-    }
 
-    if (connection.rooms.indexOf(room) >= 0) {
-      const index = connection.rooms.indexOf(room);
-      connection.rooms.splice(index, 1);
+      if (connection.rooms.includes(room)) {
+        const index = connection.rooms.indexOf(room);
+        connection.rooms.splice(index, 1);
+      }
+
       await client().hdel(api.chatRoom.keys.members + room, connection.id);
     }
 


### PR DESCRIPTION
Fixes 2 related bugs about the storing and reading of chatRoom member details.  

Prior to this PR, we were not properly awaiting the (newly optionally) async methods `chatRoom.roomStatus` and `chatRoom.generateMemberDetails`, leading to empty hashes of data stored in redis for these connections.  This was visible most noticeably when calling `chatRoom.roomStatus()` and not seeing any information for the other members of the room.

Closes https://github.com/actionhero/actionhero/issues/1958