### PR TITLE
Do not throw on race-condition when creating client JS directory

### DIFF
--- a/src/servers/websocket.ts
+++ b/src/servers/websocket.ts
@@ -204,7 +204,7 @@ export class WebSocketServer extends Server {
       const clientJSFullPath = clientJSPath + clientJSName;
       try {
         if (!fs.existsSync(clientJSPath)) {
-          fs.mkdirSync(clientJSPath);
+          fs.mkdirSync(clientJSPath, { recursive: true });
         }
         fs.writeFileSync(clientJSFullPath + ".js", this.renderClientJS());
         log(`wrote ${clientJSFullPath}.js`, "debug");


### PR DESCRIPTION
Closes https://github.com/actionhero/actionhero/issues/1965

This PR use `fs.mkdirSync(path, { recursive: true });` to not throw if there was a race condition with 2 actionhero processes trying to create the client js lib's directory at the same time.  This was likely to happen in fast tests. 

```
$ node
Welcome to Node.js v16.6.1.
Type ".help" for more information.

> const fs = require('fs')
undefined
> fs.mkdirSync('/tmp/foo')
undefined
> fs.mkdirSync('/tmp/foo')
Uncaught Error: EEXIST: file already exists, mkdir '/tmp/foo'
    at Object.mkdirSync (node:fs:1324:3) {
  errno: -17,
  syscall: 'mkdir',
  code: 'EEXIST',
  path: '/tmp/foo'
}
> fs.mkdirSync('/tmp/foo', {recursive: true})
undefined
```