### PR TITLE
specHelper runAction runTask runFullTask generic type variable can be optional

### DIFF
--- a/src/modules/specHelper.ts
+++ b/src/modules/specHelper.ts
@@ -15,7 +15,7 @@ export namespace specHelper {
   /**
    * Run an action via the specHelper server.
    */
-  export async function runAction<A extends Action>(
+  export async function runAction<A extends Action | void = void>(
     actionName: string,
     input: { [key: string]: any } = {}
   ) {
@@ -31,7 +31,9 @@ export namespace specHelper {
     connection.params.action = actionName;
 
     connection.messageId = connection.params.messageId || uuid.v4();
-    const response: (A extends Action ? UnwrapPromise<A["run"]> : any) & {
+    const response: (A extends Action
+      ? UnwrapPromise<A["run"]>
+      : { [key: string]: any }) & {
       messageId?: string;
       error?: Error | string | any;
       requesterInformation?: ReturnType<WebServer["buildRequesterInformation"]>;
@@ -64,7 +66,7 @@ export namespace specHelper {
    * Use the specHelper to run a task.
    * Note: this only runs the task's `run()` method, and no middleware.  This is faster than api.specHelper.runFullTask.
    */
-  export async function runTask<T extends Task>(
+  export async function runTask<T extends Task | void = void>(
     taskName: string,
     params: object | Array<any>
   ) {
@@ -72,7 +74,9 @@ export namespace specHelper {
       throw new Error(`task ${taskName} not found`);
     }
 
-    const result: (T extends Task ? UnwrapPromise<T["run"]> : any) & {
+    const result: (T extends Task
+      ? UnwrapPromise<T["run"]>
+      : { [key: string]: any }) & {
       error?: Error | string;
     } = await api.tasks.tasks[taskName].run(params, undefined);
     return result;
@@ -82,7 +86,7 @@ export namespace specHelper {
    * Use the specHelper to run a task.
    * Note: this will run a full Task worker, and will also include any middleware.  This is slower than api.specHelper.runTask.
    */
-  export async function runFullTask<T extends Task>(
+  export async function runFullTask<T extends Task | void = void>(
     taskName: string,
     params: object | Array<any>
   ) {
@@ -102,7 +106,9 @@ export namespace specHelper {
 
     try {
       await worker.connect();
-      const result: (T extends Task ? UnwrapPromise<T["run"]> : any) & {
+      const result: (T extends Task
+        ? UnwrapPromise<T["run"]>
+        : { [key: string]: any }) & {
         error?: string;
       } = await worker.performInline(
         taskName,


### PR DESCRIPTION
I think it can be divided into two parts: generic type and return type from ```specHelper.runAction<A>()```

1. generic type from ```specHelper.runAction<A>()```
I choose to define the generic type as ```A extends Action | void = void```.  This allows to not provide type and if provide type, it must be ```Action```

- provide ```Action``` will be passed
![image](https://user-images.githubusercontent.com/50436331/139587591-25e30cd6-e403-4386-a8f4-185bfac70236.png)
- not provide type will be ```void``` and passed
![image](https://user-images.githubusercontent.com/50436331/139587609-6fe17921-a653-46ce-be6c-26a4182f7d6d.png)
- provide not ```Action```(provide ```Task```) will be rejected
![image](https://user-images.githubusercontent.com/50436331/139587626-e657584f-c8cc-438f-9818-557883c1fea8.png)


2. return type from ```specHelper.runAction<A>()```
Providing ```Action``` will be the same as before. But if no type is provided(as provide ```void```), the "non-strict" type will be returned. The returned type should have some useful info(#2003 ), so I choose ```{[key: string]: any} & RequestExtraInfos```(For convenience, the type in the figure below will be called "RequestExtraInfos"), not ```any & RequestExtraInfos```,  because ```any & RequestExtraInfos``` will be ```any```.  This is not what we expected
![image](https://user-images.githubusercontent.com/50436331/139588608-a7c0677f-7e0a-45a9-ade7-eaddfbf4127e.png)

And I have the same idea about ```specHelper.runTask``` and ```specHelper.runFullTask```, so I also make changes