### PR TITLE
Simplify the arguments to action formatters and validators

### DIFF
--- a/src/classes/actionProcessor.ts
+++ b/src/classes/actionProcessor.ts
@@ -257,7 +257,7 @@ export class ActionProcessor<ActionClass extends Action> {
     // default
     if (params[key] === undefined && props.default !== undefined) {
       if (typeof props.default === "function") {
-        params[key] = await props.default.call(api, params[key], this);
+        params[key] = await props.default.call(this, params[key]);
       } else {
         params[key] = props.default;
       }
@@ -272,10 +272,10 @@ export class ActionProcessor<ActionClass extends Action> {
       for (const i in props.formatter) {
         const formatter = props.formatter[i];
         if (typeof formatter === "function") {
-          params[key] = await formatter.call(api, params[key], this);
+          params[key] = await formatter.call(this, params[key]);
         } else {
           const method = this.prepareStringMethod(formatter);
-          params[key] = await method.call(api, params[key], this);
+          params[key] = await method.call(this, params[key]);
         }
       }
     }
@@ -291,10 +291,10 @@ export class ActionProcessor<ActionClass extends Action> {
         let validatorResponse;
         try {
           if (typeof validator === "function") {
-            validatorResponse = await validator.call(api, params[key], this);
+            validatorResponse = await validator.call(this, params[key]);
           } else {
             const method = this.prepareStringMethod(validator);
-            validatorResponse = await method.call(api, params[key], this);
+            validatorResponse = await method.call(this, params[key]);
           }
 
           // validator function returned nothing; assume param is OK


### PR DESCRIPTION
This PR simplifies the arguments Actions pass to input Default, Formatters, and Validators.  Before this PR a second argument of `this` would be passed, which was the `api` object for some reason.  Now that accessing the `api` is object is as simple as `import {api} from 'actionhero'` this isn't needed.  This means that there are no un-expected inputs to your input methods.  

This PR also clarifies that the `this` scope of input methods is the Action Processor itself - so you'll have access to the action's class, the connection, etc - the same as `data` on the Action' s run method if you need it though `this.connection` and `this.actionTemplate`. 

This is technically a breaking change, although I don't think that was used... 