### PR TITLE
Fix cluster import

### DIFF
--- a/src/classes/process/id.ts
+++ b/src/classes/process/id.ts
@@ -1,4 +1,4 @@
-import cluster from "cluster";
+import * as cluster from "cluster";
 import { config } from "./../../modules/config";
 import { utils } from "../../modules/utils";
 
@@ -21,6 +21,7 @@ function determineId() {
     }
 
     id = externalIP;
+    // @ts-ignore - we need to load * as for node v16 support
     if (cluster["isWorker"]) id += `:${process.pid}`;
   } else {
     id = config.general.id;


### PR DESCRIPTION
The changes made in https://github.com/actionhero/actionhero/pull/2014 around the cluster module need to be reverted.  The `@types` for this package are incorrect.  Crazy!


```ts
// not working

import cluster from "cluster";
console.log(cluster); // --> undefined

// working
import * as cluster from "cluster";
console.log(cluster); // --> 

EventEmitter {
  _events: [Object: null prototype] {},
  _eventsCount: 0,
  _maxListeners: undefined,
  isWorker: false,
  isMaster: true,
  isPrimary: true,
  Worker: [Function: Worker],
  workers: {},
  settings: {},
  SCHED_NONE: 1,
  SCHED_RR: 2,
  schedulingPolicy: 2,
  setupPrimary: [Function (anonymous)],
  setupMaster: [Function (anonymous)],
  fork: [Function (anonymous)],
  disconnect: [Function (anonymous)],
  [Symbol(kCapture)]: false
}
```