### PR TITLE
use global flag in swagger path substitution

### DIFF
--- a/__tests__/actions/swagger.ts
+++ b/__tests__/actions/swagger.ts
@@ -1,13 +1,52 @@
 process.env.AUTOMATIC_ROUTES = "get";
 
-import { Process, specHelper, config } from "./../../src/index";
+import { Process, specHelper, config, api } from "./../../src/index";
 import { Swagger } from "../../src/actions/swagger";
 
 describe("Action: swagger", () => {
   const actionhero = new Process();
+  let originalRoutes: typeof api.routes.routes;
 
-  beforeAll(async () => await actionhero.start());
-  afterAll(async () => await actionhero.stop());
+  beforeAll(async () => {
+    await actionhero.start();
+
+    originalRoutes = api.routes.routes;
+    api.actions.versions.multiParamTestAction = [1];
+    api.actions.actions.multiParamTestAction = {
+      // @ts-ignore
+      1: {
+        name: "multiParamTestAction",
+        description: "I am a multiple param test action",
+        inputs: {
+          one: { required: true },
+          two: { required: true },
+          three: { required: true },
+          four: { required: true },
+        },
+        outputExample: {},
+        run: async (data) => {
+          data.response.success = true;
+        },
+      },
+    };
+
+    api.routes.loadRoutes({
+      get: [
+        {
+          path: "/v:apiVersion/one/:one/two/:two/three/:three/four/:four",
+          action: "multiParamTestAction",
+        },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await actionhero.stop();
+
+    api.routes.routes = originalRoutes;
+    delete api.actions.versions.multiParamTestAction;
+    delete api.actions.actions.multiParamTestAction;
+  });
 
   test("automatic routes is enabled", () => {
     expect(config.web.automaticRoutes).toEqual(["get"]);
@@ -20,6 +59,19 @@ describe("Action: swagger", () => {
 
     expect(basePath).toBe("/api/");
     expect(host).toMatch(/localhost/);
-    expect(Object.keys(paths).length).toEqual(9); // 9 actions
+    expect(Object.keys(paths).length).toEqual(11); // 10 actions + custom multiParamTestAction path
+
+    const multiParamPath =
+      paths["/one/{one}/two/{two}/three/{three}/four/{four}"];
+    expect(multiParamPath).toBeDefined();
+    expect(multiParamPath.get.summary).toBe(
+      "I am a multiple param test action"
+    );
+    expect(multiParamPath.get.parameters.map((p) => p.name).sort()).toEqual([
+      "four",
+      "one",
+      "three",
+      "two",
+    ]);
   });
 });

--- a/src/actions/swagger.ts
+++ b/src/actions/swagger.ts
@@ -79,11 +79,7 @@ export class Swagger extends Action {
         const tag = action.name.split(":")[0];
         const formattedPath = route.path
           .replace("/v:apiVersion", "")
-          .replace(/\/:(\w*)/, "/{$1}")
-          .replace(/\/:(\w*)/, "/{$1}")
-          .replace(/\/:(\w*)/, "/{$1}")
-          .replace(/\/:(\w*)/, "/{$1}")
-          .replace(/\/:(\w*)/, "/{$1}");
+          .replace(/\/:(\w*)/g, "/{$1}");
 
         swaggerPaths[formattedPath] = swaggerPaths[formattedPath] || {};
         swaggerPaths[formattedPath][method] = {


### PR DESCRIPTION
Allows replacement of more than 5 variables in the path by using the global flag in the regex. This works because technically `$1` is still the first capture group in the provided regex.