### PR TITLE
Do not assume that all uses of Actionhero in test are running typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "actionhero",
-  "version": "28.0.3",
+  "version": "28.0.4-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "actionhero",
-      "version": "28.0.3",
+      "version": "28.0.4-alpha.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Evan Tahler <evantahler@gmail.com>",
   "name": "actionhero",
   "description": "The reusable, scalable, and quick node.js API server for stateless and stateful applications",
-  "version": "28.0.3",
+  "version": "28.0.4-alpha.0",
   "homepage": "http://www.actionherojs.com",
   "license": "Apache-2.0",
   "repository": {

--- a/src/classes/process/typescript.ts
+++ b/src/classes/process/typescript.ts
@@ -11,8 +11,11 @@ function isTypescript(): boolean {
   // if this file is typescript, we are running typescript :D
   // this is the best check, but fails when actionhero is compiled to js though...
   const extension = path.extname(__filename);
-  if (extension === ".ts") {
-    return true;
+  if (extension === ".ts") return true;
+
+  // is the script that was executed a TS script? Check for a *.ts filename somewhere in the process arguments
+  for (const arg of process.argv) {
+    if (arg.match(/.+\.ts$/)) return true;
   }
 
   // are we running via a ts-node/ts-node-dev shim?
@@ -28,15 +31,14 @@ function isTypescript(): boolean {
      */
 
     // @ts-ignore
-    return process[Symbol.for("ts-node.register.instance")] ||
-      (process.env.NODE_ENV === "test" &&
-        process.env.ACTIONHERO_TYPESCRIPT_MODE?.toLowerCase() !== "false")
-      ? true
-      : false;
+    if (process[Symbol.for("ts-node.register.instance")]) return true;
   } catch (error) {
     console.error(error);
     return false;
   }
+
+  // We didn't find a reason to suspect we are running TS, so return false
+  return false;
 }
 
 export const typescript = isTypescript();


### PR DESCRIPTION
We need to know if Actionhero is running in Typescript (via `ts-node`, `ts-node-dev`, `jest`, or similar) to determine if we should load `/src/config/*.ts` or `/dist/config/*.js`

Prior to this PR, we assumed that any time that `NODE_ENV=test`, we should be running typescript and load the typescript config files.  This prevented anyone from using a CLI Actionhero command in CI.  This new way of guessing if we are running in typescript should be a bit safer.