### PR TITLE
`ParamsFrom` utility to determine types of params from Action Inputs

### DIFF
--- a/src/actions/cacheTest.ts
+++ b/src/actions/cacheTest.ts
@@ -1,39 +1,36 @@
-import { cache, Action } from "./../index";
+import { cache, Action, ParamsFrom } from "./../index";
 
 export class CacheTest extends Action {
-  constructor() {
-    super();
-    this.name = "cacheTest";
-    this.description = "I will test the internal cache functions of the API";
-    this.inputs = {
-      key: {
-        required: true,
-        formatter: this.stringFormatter,
-        validator: this.stringValidator,
-      },
+  name = "cacheTest";
+  description = "I will test the internal cache functions of the API";
+  inputs = {
+    key: {
+      required: true,
+      formatter: this.stringFormatter,
+      validator: this.stringValidator,
+    },
 
-      value: {
-        required: true,
-        formatter: this.stringFormatter,
-        validator: this.stringValidator,
-      },
-    };
+    value: {
+      required: true,
+      formatter: this.stringFormatter,
+      validator: this.stringValidator,
+    },
+  };
 
-    this.outputExample = {
-      cacheTestResults: {
-        saveResp: true,
-        sizeResp: 1,
-        loadResp: {
-          key: "cacheTest_key",
-          value: "value",
-          expireTimestamp: 1420953274716,
-          createdAt: 1420953269716,
-          readAt: null,
-        },
-        deleteResp: true,
+  outputExample = {
+    cacheTestResults: {
+      saveResp: true,
+      sizeResp: 1,
+      loadResp: {
+        key: "cacheTest_key",
+        value: "value",
+        expireTimestamp: 1420953274716,
+        createdAt: 1420953269716,
+        readAt: null as number,
       },
-    };
-  }
+      deleteResp: true,
+    },
+  };
 
   stringFormatter(s: unknown) {
     return String(s);
@@ -47,7 +44,7 @@ export class CacheTest extends Action {
     }
   }
 
-  async run({ params }: { params: { key: string; value: string } }) {
+  async run({ params }: { params: ParamsFrom<CacheTest> }) {
     const key = `cacheTest_${params.key}`;
     const value = params.value;
 

--- a/src/actions/createChatRoom.ts
+++ b/src/actions/createChatRoom.ts
@@ -1,18 +1,13 @@
-import { chatRoom, Action } from "./../index";
+import { chatRoom, Action, ParamsFrom } from "./../index";
 
 export class CreateChatRoom extends Action {
-  constructor() {
-    super();
-    this.name = "createChatRoom";
-    this.description = "I will create a chatroom with the given name";
-    this.inputs = {
-      name: {
-        required: true,
-      },
-    };
-  }
+  name = "createChatRoom";
+  description = "I will create a chatroom with the given name";
+  inputs = {
+    name: { required: true },
+  };
 
-  async run({ params }: { params: { name: string } }) {
+  async run({ params }: { params: ParamsFrom<CreateChatRoom> }) {
     let didCreate = false;
 
     if (!(await chatRoom.exists(params.name))) {

--- a/src/actions/randomNumber.ts
+++ b/src/actions/randomNumber.ts
@@ -1,15 +1,12 @@
 import { Action } from "./../index";
 
 export class RandomNumber extends Action {
-  constructor() {
-    super();
-    this.name = "randomNumber";
-    this.description = "I am an API method which will generate a random number";
-    this.outputExample = {
-      randomNumber: 0.123,
-      stringRandomNumber: "Your random number is 0.123",
-    };
-  }
+  name = "randomNumber";
+  description = "I am an API method which will generate a random number";
+  outputExample = {
+    randomNumber: 0.123,
+    stringRandomNumber: "Your random number is 0.123",
+  };
 
   async run() {
     const randomNumber = Math.random();

--- a/src/actions/recursiveAction.ts
+++ b/src/actions/recursiveAction.ts
@@ -1,12 +1,9 @@
 import { Action, action } from "./../index";
 
 export class RecursiveAction extends Action {
-  constructor() {
-    super();
-    this.name = "recursiveAction";
-    this.description = "I am an action that runs another action";
-    this.outputExample = {};
-  }
+  name = "recursiveAction";
+  description = "I am an action that runs another action";
+  outputExample = {};
 
   async run() {
     const localResponse = { local: true };

--- a/src/actions/sendFile.ts
+++ b/src/actions/sendFile.ts
@@ -1,12 +1,9 @@
 import { Action, Connection } from "../index";
 
 export class SendFile extends Action {
-  constructor() {
-    super();
-    this.name = "sendFile";
-    this.description = "I send a file though an action";
-    this.outputExample = {};
-  }
+  name = "sendFile";
+  description = "I send a file though an action";
+  outputExample = {};
 
   async run(data: { connection: Connection; toRender: boolean }) {
     await data.connection.sendFile("logo/actionhero.png");

--- a/src/actions/sleepTest.ts
+++ b/src/actions/sleepTest.ts
@@ -7,28 +7,25 @@ function sleep(time: number): Promise<void> {
 }
 
 export class SleepTest extends Action {
-  constructor() {
-    super();
-    this.name = "sleepTest";
-    this.description = "I will sleep and then return";
-    this.inputs = {
-      sleepDuration: {
-        required: true,
-        formatter: (n: string) => {
-          return parseInt(n);
-        },
-        default: () => {
-          return 1000;
-        },
+  name = "sleepTest";
+  description = "I will sleep and then return";
+  inputs = {
+    sleepDuration: {
+      required: true,
+      formatter: (n: string) => {
+        return parseInt(n);
       },
-    };
-    this.outputExample = {
-      sleepStarted: 1420953571322,
-      sleepEnded: 1420953572327,
-      sleepDelta: 1005,
-      sleepDuration: 1000,
-    };
-  }
+      default: () => {
+        return 1000;
+      },
+    },
+  };
+  outputExample = {
+    sleepStarted: 1420953571322,
+    sleepEnded: 1420953572327,
+    sleepDelta: 1005,
+    sleepDuration: 1000,
+  };
 
   async run({ params }: { params: { sleepDuration: number } }) {
     const sleepDuration = params.sleepDuration;

--- a/src/actions/status.ts
+++ b/src/actions/status.ts
@@ -21,16 +21,13 @@ const packageJSON: PackageJson = JSON.parse(
 );
 
 export class Status extends Action {
-  constructor() {
-    super();
-    this.name = "status";
-    this.description = "I will return some basic information about the API";
-    this.outputExample = {
-      id: "192.168.2.11",
-      actionheroVersion: "9.4.1",
-      uptime: 10469,
-    };
-  }
+  name = "status";
+  description = "I will return some basic information about the API";
+  outputExample = {
+    id: "192.168.2.11",
+    actionheroVersion: "9.4.1",
+    uptime: 10469,
+  };
 
   async run() {
     let nodeStatus = StatusMessages.healthy;

--- a/src/actions/swagger.ts
+++ b/src/actions/swagger.ts
@@ -28,12 +28,9 @@ const responses = {
 };
 
 export class Swagger extends Action {
-  constructor() {
-    super();
-    this.name = "swagger";
-    this.description = "return API documentation in the OpenAPI specification";
-    this.outputExample = {};
-  }
+  name = "swagger";
+  description = "return API documentation in the OpenAPI specification";
+  outputExample = {};
 
   getLatestAction(route: RouteType) {
     let matchedAction: Action;

--- a/src/actions/validationTest.ts
+++ b/src/actions/validationTest.ts
@@ -1,22 +1,19 @@
 import { Action } from "./../index";
 
 export class ValidationTest extends Action {
-  constructor() {
-    super();
-    this.name = "validationTest";
-    this.description = "I will test action input validators.";
-    this.inputs = {
-      string: {
-        required: true,
-        validator: (param: string) => {
-          return typeof param === "string";
-        },
+  name = "validationTest";
+  description = "I will test action input validators.";
+  inputs = {
+    string: {
+      required: true,
+      validator: (param: string) => {
+        return typeof param === "string";
       },
-    };
-    this.outputExample = {
-      string: "imAString!",
-    };
-  }
+    },
+  };
+  outputExample = {
+    string: "imAString!",
+  };
 
   async run({ params }: { params: { string: string } }) {
     return { string: params.string };

--- a/src/classes/inputs.ts
+++ b/src/classes/inputs.ts
@@ -1,5 +1,15 @@
 import { Input } from "./input";
+import { Action } from "../classes/action";
+import { Task } from "../classes/task";
 
 export interface Inputs {
   [key: string]: Input;
 }
+
+export type ParamsFrom<A extends Action | Task> = {
+  [Input in keyof A["inputs"]]: A["inputs"][Input]["formatter"] extends (
+    ...ags: any[]
+  ) => any
+    ? ReturnType<A["inputs"][Input]["formatter"]>
+    : string;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ export { Server } from "./classes/server";
 export { CLI } from "./classes/cli";
 export { ActionProcessor } from "./classes/actionProcessor";
 export { PluginConfig } from "./classes/config";
+export { Inputs, ParamsFrom } from "./classes/inputs";
+export { Input } from "./classes/input";
 
 // export modules (lower case)
 export { utils } from "./modules/utils";

--- a/src/tasks/runAction.ts
+++ b/src/tasks/runAction.ts
@@ -1,22 +1,18 @@
-import { Action } from "../classes/action";
-import { log, Task, action } from "./../index";
+import { log, Task, action, ParamsFrom } from "./../index";
 
 export class RunAction extends Task {
-  constructor() {
-    super();
-    this.name = "runAction";
-    this.description = "I will run an action and return the connection object";
-    this.frequency = 0;
-    this.queue = "default";
-    this.middleware = [];
-  }
+  name = "runAction";
+  description = "I will run an action and return the connection object";
+  frequency = 0;
+  queue = "default";
 
-  async run(params: Record<string, any>) {
+  async run(params: ParamsFrom<RunAction>) {
     if (!params) params = {};
 
     const response = await action.run(
       params.action,
       params.version,
+      // @ts-ignore
       params.params
     );
 


### PR DESCRIPTION
The new `ParamsFrom` TS utility can *finally* help dynamically determine the param types of an Action's run method!  This only works on Action classes that **statically** define the inputs, e.g. NOT in a constructor.  Here's a screenshot of things working:

<img width="594" alt="Screen Shot 2021-12-20 at 7 14 01 PM" src="https://user-images.githubusercontent.com/303226/146864832-19cde19f-b861-4a3c-a4f4-ff52a47208a9.png">


Note that `params.value` is properly a string, and we get an error that `params.foo` is undefined.


Here's the magic:
```ts
export type ParamsFrom<A extends Action | Task> = {
  [Input in keyof A["inputs"]]: A["inputs"][Input]["formatter"] extends (
    ...ags: any[]
  ) => any
    ? ReturnType<A["inputs"][Input]["formatter"]>
    : string;
};
```

What's nice about this approach is that we don't need to change any of Actionhero's internals, but we should start writing all of our Actions and Tasks with static definitions. 