### PR TITLE
use commander to handle cli `formatter`/`validator`

### DIFF
--- a/__tests__/cli/cli.ts
+++ b/__tests__/cli/cli.ts
@@ -1,14 +1,6 @@
 import * as ChildProcess from "child_process";
 import * as path from "path";
 
-process.env.ACTIONHERO_CONFIG_OVERRIDES = JSON.stringify({
-  general: {
-    paths: {
-      cli: [path.join(__dirname, "..", "testCliCommands")],
-    },
-  },
-});
-
 async function exec(
   command: string,
   args: Record<string, any>
@@ -26,7 +18,17 @@ async function exec(
 }
 
 describe("cli commands", () => {
-  const env = process.env;
+  const env = {
+    ...process.env,
+    ACTIONHERO_CONFIG_OVERRIDES: JSON.stringify({
+      general: {
+        paths: {
+          cli: [path.join(__dirname, "..", "testCliCommands")],
+        },
+      },
+    }),
+  };
+
   test(
     "new commands appear in help",
     async () => {

--- a/__tests__/cli/cli.ts
+++ b/__tests__/cli/cli.ts
@@ -1,0 +1,109 @@
+import * as ChildProcess from "child_process";
+import * as path from "path";
+
+process.env.ACTIONHERO_CONFIG_OVERRIDES = JSON.stringify({
+  general: {
+    paths: {
+      cli: [path.join(__dirname, "..", "testCliCommands")],
+    },
+  },
+});
+
+async function exec(
+  command: string,
+  args: Record<string, any>
+): Promise<{
+  error?: NodeJS.ErrnoException;
+  stdout?: string;
+}> {
+  return new Promise((resolve, reject) => {
+    ChildProcess.exec(command, args, (error, stdout, stderr) => {
+      if (error) return reject(error);
+      if (stderr) return reject(stderr);
+      return resolve({ stdout: stdout.toString() });
+    });
+  });
+}
+
+describe("cli commands", () => {
+  const env = process.env;
+  test(
+    "new commands appear in help",
+    async () => {
+      const { stdout } = await exec(
+        "./node_modules/.bin/ts-node ./src/bin/actionhero.ts help",
+        { env }
+      );
+      expect(stdout).toContain("hello");
+    },
+    30 * 1000
+  );
+
+  test(
+    "can run",
+    async () => {
+      const { stdout } = await exec(
+        "./node_modules/.bin/ts-node ./src/bin/actionhero.ts hello",
+        { env }
+      );
+      expect(stdout).toContain("Hello, Dr. World");
+    },
+    30 * 1000
+  );
+
+  test(
+    "can format inputs",
+    async () => {
+      const { stdout } = await exec(
+        "./node_modules/.bin/ts-node ./src/bin/actionhero.ts hello -t Mr --name Worldwide ",
+        { env }
+      );
+      expect(stdout).toContain("Hello, Mr. Worldwide");
+    },
+    30 * 1000
+  );
+
+  test(
+    "can validate inputs",
+    async () => {
+      await expect(
+        exec(
+          "./node_modules/.bin/ts-node ./src/bin/actionhero.ts hello -t Esq. --name Worldwide ",
+          { env }
+        )
+      ).rejects.toThrow(
+        /error: option '-t, --title <title>' argument 'Esq.' is invalid. too many periods/
+      );
+    },
+    30 * 1000
+  );
+
+  test(
+    "can format variadic inputs individually",
+    async () => {
+      const { stdout } = await exec(
+        "./node_modules/.bin/ts-node ./src/bin/actionhero.ts hello --title Mr --name Worldwide --countries France Italy Germany USA",
+        { env }
+      );
+      expect(stdout).toContain(
+        "Hello, Mr. Worldwide (France! Italy! Germany! USA!)"
+      );
+    },
+    30 * 1000
+  );
+
+  test(
+    "can validate variadic inputs individually",
+    async () => {
+      await expect(
+        exec(
+          "./node_modules/.bin/ts-node ./src/bin/actionhero.ts hello --title Mr --name Worldwide --countries France italy",
+          { env }
+        )
+      ).rejects.toThrow(
+        /error: option '--countries \[countries...\]' argument 'italy' is invalid. country not capitalized/
+      );
+    },
+    30 * 1000
+  );
+});

--- a/__tests__/testCliCommands/hello.ts
+++ b/__tests__/testCliCommands/hello.ts
@@ -1,0 +1,41 @@
+import { CLI, ParamsFrom } from "./../../src/index";
+
+export class HelloCliTest extends CLI {
+  name = "hello";
+  description = "I work";
+  inputs = {
+    name: {
+      required: false,
+      default: "World",
+    },
+    title: {
+      letter: "t",
+      required: true,
+      default: "Dr.",
+      formatter: (val: string) => {
+        return `${val}.`;
+      },
+      validator: (val: string) => {
+        const parts = val.split(".");
+        if (parts.length > 2) throw new Error("too many periods");
+      },
+    },
+    countries: {
+      variadic: true as const,
+      formatter: (val: string) => `${val}!`,
+      validator: (val: string) => {
+        if (val.length > 0 && val[0].toUpperCase() !== val[0])
+          throw new Error("country not capitalized");
+      },
+    },
+  };
+
+  async run({ params }: { params: Partial<ParamsFrom<HelloCliTest>> }) {
+    console.log(
+      `Hello, ${params.title} ${params.name} ${
+        params.countries ? `(${params.countries.join(" ")})` : ""
+      }`
+    );
+    return true;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "maxWorkers": "50%",
     "testPathIgnorePatterns": [
       "<rootDir>/__tests__/testPlugin",
+      "<rootDir>/__tests__/testCliCommands",
       "<rootDir>/tmp"
     ],
     "transform": {

--- a/src/bin/actionhero.ts
+++ b/src/bin/actionhero.ts
@@ -3,7 +3,7 @@
 import * as path from "path";
 import * as fs from "fs";
 import * as glob from "glob";
-import { program, InvalidOptionArgumentError } from "commander";
+import { program, InvalidArgumentError } from "commander";
 import { typescript } from "../classes/process/typescript";
 import { projectRoot } from "../classes/process/projectRoot";
 import { ensureNoTsHeaderFiles } from "../modules/utils/ensureNoTsHeaderFiles";
@@ -145,7 +145,7 @@ export namespace ActionheroCLIRunner {
 
           return value;
         } catch (error) {
-          throw new InvalidOptionArgumentError(error?.message ?? error);
+          throw new InvalidArgumentError(error?.message ?? error);
         }
       };
 

--- a/src/bin/actionhero.ts
+++ b/src/bin/actionhero.ts
@@ -3,7 +3,7 @@
 import * as path from "path";
 import * as fs from "fs";
 import * as glob from "glob";
-import { program } from "commander";
+import { program, InvalidOptionArgumentError } from "commander";
 import { typescript } from "../classes/process/typescript";
 import { projectRoot } from "../classes/process/projectRoot";
 import { ensureNoTsHeaderFiles } from "../modules/utils/ensureNoTsHeaderFiles";
@@ -124,7 +124,37 @@ export namespace ActionheroCLIRunner {
             }${separators[1]}`
       }`;
 
-      command[methodName](argString, input.description, input.default);
+      const argProcessor = (
+        value: string,
+        accumulator?: unknown[]
+      ): unknown => {
+        try {
+          if (typeof input.formatter === "function") {
+            value = input.formatter(value);
+          }
+
+          if (typeof input.validator === "function") {
+            input.validator(value);
+          }
+
+          if (input.variadic) {
+            if (!Array.isArray(accumulator)) accumulator = [];
+            accumulator.push(value);
+            return accumulator;
+          }
+
+          return value;
+        } catch (error) {
+          throw new InvalidOptionArgumentError(error?.message ?? error);
+        }
+      };
+
+      command[methodName](
+        argString,
+        input.description,
+        argProcessor,
+        input.default
+      );
     }
   }
 
@@ -149,16 +179,6 @@ export namespace ActionheroCLIRunner {
     });
 
     params["_arguments"] = _arguments;
-
-    for (const [key, inputOpts] of Object.entries(instance.inputs)) {
-      if (typeof inputOpts.formatter === "function") {
-        params[key] = await inputOpts.formatter(params[key]);
-      }
-
-      if (typeof inputOpts.validator === "function") {
-        await inputOpts.validator(params[key]);
-      }
-    }
 
     if (instance.initialize === false && instance.start === false) {
       toStop = await instance.run({ params });

--- a/src/classes/inputs.ts
+++ b/src/classes/inputs.ts
@@ -7,10 +7,20 @@ export interface Inputs {
   [key: string]: Input;
 }
 
-export type ParamsFrom<A extends Action | Task | CLI> = {
-  [Input in keyof A["inputs"]]: A["inputs"][Input]["formatter"] extends (
-    ...ags: any[]
-  ) => any
-    ? ReturnType<A["inputs"][Input]["formatter"]>
-    : string;
-};
+export type ParamsFrom<A extends Action | Task | CLI> = A extends CLI
+  ? {
+      [Input in keyof A["inputs"]]: A["inputs"][Input]["variadic"] extends true
+        ? A["inputs"][Input]["formatter"] extends (...ags: any[]) => any
+          ? ReturnType<A["inputs"][Input]["formatter"]>[]
+          : string[]
+        : A["inputs"][Input]["formatter"] extends (...ags: any[]) => any
+        ? ReturnType<A["inputs"][Input]["formatter"]>
+        : string;
+    }
+  : {
+      [Input in keyof A["inputs"]]: A["inputs"][Input]["formatter"] extends (
+        ...ags: any[]
+      ) => any
+        ? ReturnType<A["inputs"][Input]["formatter"]>
+        : string;
+    };


### PR DESCRIPTION
Moves to using commander's [built-in option processing](https://github.com/tj/commander.js#custom-option-processing) when running `formatter` and `validator` functions on CLI inputs.

This lets commander give us better output in the case of validation errors (as opposed to showing a full stack trace as currently happens).

```
▲ actionhero % actionhero something --test blah.
error: option '--test [test]' argument 'blah.' is invalid. blah. isnt valid because periods are bad
```


**Possibly breaking**: `formatter` and `validator` can no longer be asynchronous for CLI inputs.