### PR TITLE
cli command optional inputs can require a value

### DIFF
--- a/__tests__/cli/cli.ts
+++ b/__tests__/cli/cli.ts
@@ -66,6 +66,21 @@ describe("cli commands", () => {
   );
 
   test(
+    "can require a value when optional inputs are specified",
+    async () => {
+      await expect(
+        exec(
+          "./node_modules/.bin/ts-node ./src/bin/actionhero.ts hello --name",
+          {
+            env,
+          }
+        )
+      ).rejects.toThrow(/error: option '--name <name>' argument missing/);
+    },
+    30 * 1000
+  );
+
+  test(
     "can validate inputs",
     async () => {
       await expect(

--- a/__tests__/testCliCommands/hello.ts
+++ b/__tests__/testCliCommands/hello.ts
@@ -6,6 +6,7 @@ export class HelloCliTest extends CLI {
   inputs = {
     name: {
       required: false,
+      requiredValue: true,
       default: "World",
     },
     title: {

--- a/src/bin/actionhero.ts
+++ b/src/bin/actionhero.ts
@@ -114,7 +114,8 @@ export namespace ActionheroCLIRunner {
         );
       }
 
-      const separators = input.required ? ["<", ">"] : ["[", "]"];
+      const separators =
+        input.required || input.requiredValue ? ["<", ">"] : ["[", "]"];
       const methodName = input.required ? "requiredOption" : "option";
       const argString = `${input.letter ? `-${input.letter}, ` : ""}--${key} ${
         input.flag

--- a/src/classes/cli.ts
+++ b/src/classes/cli.ts
@@ -13,6 +13,7 @@ export abstract class CLI {
   inputs: {
     [key: string]: {
       required?: boolean;
+      requiredValue?: boolean;
       default?: string | boolean;
       letter?: string;
       flag?: boolean;


### PR DESCRIPTION
When using non-required CLI inputs, the use of the `[ ]` separators means it's allowed to pass in the option without a value, getting a boolean in return:

```js
program
  .option('-c, --cheese [type]', 'Add cheese with optional type');

program.parse(process.argv);

const options = program.opts();
if (options.cheese === undefined) console.log('no cheese');
else if (options.cheese === true) console.log('add cheese');
else console.log(`add cheese type ${options.cheese}`);
```

```
$ pizza-options
no cheese
$ pizza-options --cheese
add cheese
$ pizza-options --cheese mozzarella
add cheese type mozzarella
```
(example from https://github.com/tj/commander.js#other-option-types-negatable-boolean-and-booleanvalue)

However, when passing an option we often dont want to allow the boolean case and want to instead use the `< >` separators to require a value to be passed and let commander handle the validation.

This PR introduces a `requiredValue` option for inputs to use `<>` separators and enable this use case. I would argue this is the default expected behavior, but this seemed like the best way to make it a non-breaking change.

This means now, when `requiredValue: true`, commander will throw a nice error and we won't get unexpected booleans when running the command:

```
$ actionhero hello --name
error: option '--name <name>' argument missing
```

 
