### PR TITLE
fix `ParamsFrom` type inference

### DIFF
--- a/__tests__/testCliCommands/hello.ts
+++ b/__tests__/testCliCommands/hello.ts
@@ -1,4 +1,4 @@
-import { CLI, ParamsFrom } from "./../../src/index";
+import { CLI, CLIParamsFrom } from "./../../src/index";
 
 export class HelloCliTest extends CLI {
   name = "hello";
@@ -31,7 +31,7 @@ export class HelloCliTest extends CLI {
     },
   };
 
-  async run({ params }: { params: Partial<ParamsFrom<HelloCliTest>> }) {
+  async run({ params }: { params: Partial<CLIParamsFrom<HelloCliTest>> }) {
     console.log(
       `Hello, ${params.title} ${params.name} ${
         params.countries ? `(${params.countries.join(" ")})` : ""

--- a/__tests__/testCliCommands/hello.ts
+++ b/__tests__/testCliCommands/hello.ts
@@ -1,4 +1,4 @@
-import { CLI, CLIParamsFrom } from "./../../src/index";
+import { CLI, ParamsFrom } from "./../../src/index";
 
 export class HelloCliTest extends CLI {
   name = "hello";
@@ -22,7 +22,7 @@ export class HelloCliTest extends CLI {
       },
     },
     countries: {
-      variadic: true as const,
+      variadic: true as true,
       formatter: (val: string) => `${val}!`,
       validator: (val: string) => {
         if (val.length > 0 && val[0].toUpperCase() !== val[0])
@@ -31,12 +31,12 @@ export class HelloCliTest extends CLI {
     },
   };
 
-  async run({ params }: { params: Partial<CLIParamsFrom<HelloCliTest>> }) {
-    console.log(
-      `Hello, ${params.title} ${params.name} ${
-        params.countries ? `(${params.countries.join(" ")})` : ""
-      }`
-    );
+  async run({ params }: { params: Partial<ParamsFrom<HelloCliTest>> }) {
+    const sayHello = (title: string, name: string, countries: string[]) =>
+      console.log(
+        `Hello, ${title} ${name} ${countries ? `(${countries.join(" ")})` : ""}`
+      );
+    sayHello(params.title, params.name, params.countries);
     return true;
   }
 }

--- a/src/classes/inputs.ts
+++ b/src/classes/inputs.ts
@@ -12,12 +12,10 @@ type FormatterOrString<I extends (Action | Task | CLI)["inputs"][string]> =
     ? ReturnType<I["formatter"]>
     : string;
 
-export type CLIParamsFrom<A extends CLI> = {
-  [Input in keyof A["inputs"]]: A["inputs"][Input]["variadic"] extends true
-    ? FormatterOrString<A["inputs"][Input]>[]
-    : FormatterOrString<A["inputs"][Input]>;
-};
+type Variadic = { variadic: true };
 
 export type ParamsFrom<A extends Action | Task | CLI> = {
-  [Input in keyof A["inputs"]]: FormatterOrString<A["inputs"][Input]>;
+  [Input in keyof A["inputs"]]: A["inputs"][Input] extends Variadic
+    ? FormatterOrString<A["inputs"][Input]>[]
+    : FormatterOrString<A["inputs"][Input]>;
 };

--- a/src/classes/inputs.ts
+++ b/src/classes/inputs.ts
@@ -7,20 +7,17 @@ export interface Inputs {
   [key: string]: Input;
 }
 
-export type ParamsFrom<A extends Action | Task | CLI> = A extends CLI
-  ? {
-      [Input in keyof A["inputs"]]: A["inputs"][Input]["variadic"] extends true
-        ? A["inputs"][Input]["formatter"] extends (...ags: any[]) => any
-          ? ReturnType<A["inputs"][Input]["formatter"]>[]
-          : string[]
-        : A["inputs"][Input]["formatter"] extends (...ags: any[]) => any
-        ? ReturnType<A["inputs"][Input]["formatter"]>
-        : string;
-    }
-  : {
-      [Input in keyof A["inputs"]]: A["inputs"][Input]["formatter"] extends (
-        ...ags: any[]
-      ) => any
-        ? ReturnType<A["inputs"][Input]["formatter"]>
-        : string;
-    };
+type FormatterOrString<I extends (Action | Task | CLI)["inputs"][string]> =
+  I["formatter"] extends (...args: any[]) => any
+    ? ReturnType<I["formatter"]>
+    : string;
+
+export type CLIParamsFrom<A extends CLI> = {
+  [Input in keyof A["inputs"]]: A["inputs"][Input]["variadic"] extends true
+    ? FormatterOrString<A["inputs"][Input]>[]
+    : FormatterOrString<A["inputs"][Input]>;
+};
+
+export type ParamsFrom<A extends Action | Task | CLI> = {
+  [Input in keyof A["inputs"]]: FormatterOrString<A["inputs"][Input]>;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export { Server } from "./classes/server";
 export { CLI } from "./classes/cli";
 export { ActionProcessor } from "./classes/actionProcessor";
 export { PluginConfig } from "./classes/config";
-export { Inputs, ParamsFrom } from "./classes/inputs";
+export { Inputs, ParamsFrom, CLIParamsFrom } from "./classes/inputs";
 export { Input } from "./classes/input";
 
 // export modules (lower case)

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export { Server } from "./classes/server";
 export { CLI } from "./classes/cli";
 export { ActionProcessor } from "./classes/actionProcessor";
 export { PluginConfig } from "./classes/config";
-export { Inputs, ParamsFrom, CLIParamsFrom } from "./classes/inputs";
+export { Inputs, ParamsFrom } from "./classes/inputs";
 export { Input } from "./classes/input";
 
 // export modules (lower case)


### PR DESCRIPTION
For some reason, TypeScript has trouble inferring types properly when using `A extends CLI` as a conditional.

![image](https://user-images.githubusercontent.com/4368928/151631353-641c861b-8252-4945-ad37-99be1276fb7a.png)

You can play around with this example here https://github.com/actionhero/actionhero/commit/eee6e8dcab5bcfe795fe70c262f1d9f7b6909ab3

Separating out ParamsFrom for the CLI to it's own type lets you explicitly use it, though I'd still like to find a solution that keeps things in a single `ParamsFrom` that works for both if possible, hence the draft PR. Pushed here for visibility.
