### PR TITLE
`@types/glob` is now required for generated projects

### DIFF
--- a/templates/package.json.template
+++ b/templates/package.json.template
@@ -15,8 +15,8 @@
   },
   "devDependencies": {
     "@types/node": "latest",
-    "@types/jest": "latest",
     "@types/glob": "latest",
+    "@types/jest": "latest",
     "jest": "latest",
     "prettier": "latest",
     "ts-jest": "latest",

--- a/templates/package.json.template
+++ b/templates/package.json.template
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@types/node": "latest",
     "@types/jest": "latest",
+    "@types/glob": "latest",
     "jest": "latest",
     "prettier": "latest",
     "ts-jest": "latest",


### PR DESCRIPTION
After https://github.com/actionhero/actionhero/pull/2278, generated projects now need `@types/glob`