### PR TITLE
Webserver binds to `::` by default

### DIFF
--- a/__tests__/servers/websocket.ts
+++ b/__tests__/servers/websocket.ts
@@ -128,7 +128,7 @@ describe("Server: Web Socket", () => {
     test("I can get my connection details", async () => {
       const response = await awaitMethod(clientA, "detailsView");
       expect(response.data.connectedAt).toBeLessThan(new Date().getTime());
-      expect(response.data.remoteIP).toEqual("127.0.0.1");
+      expect(["127.0.0.1", "::1"]).toContain(response.data.remoteIP);
     });
 
     test("can run actions with errors", async () => {
@@ -768,7 +768,7 @@ describe("Server: Web Socket", () => {
 
       test("can be sent disconnect events from the server", async () => {
         const response = await awaitMethod(clientA, "detailsView");
-        expect(response.data.remoteIP).toEqual("127.0.0.1");
+        expect(["127.0.0.1", "::1"]).toContain(response.data.remoteIP);
 
         let count = 0;
         for (const id in api.connections.connections) {

--- a/__tests__/servers/websocket.ts
+++ b/__tests__/servers/websocket.ts
@@ -10,6 +10,8 @@ let clientC: any;
 
 let url: string;
 
+const localhosts = ["127.0.0.1", "::ffff:127.0.0.1", "::1"];
+
 const connectClients = async () => {
   // get ActionheroWebsocketClient in scope
   const ActionheroWebsocketClient = eval(
@@ -128,7 +130,7 @@ describe("Server: Web Socket", () => {
     test("I can get my connection details", async () => {
       const response = await awaitMethod(clientA, "detailsView");
       expect(response.data.connectedAt).toBeLessThan(new Date().getTime());
-      expect(["127.0.0.1", "::1"]).toContain(response.data.remoteIP);
+      expect(localhosts).toContain(response.data.remoteIP);
     });
 
     test("can run actions with errors", async () => {
@@ -768,7 +770,7 @@ describe("Server: Web Socket", () => {
 
       test("can be sent disconnect events from the server", async () => {
         const response = await awaitMethod(clientA, "detailsView");
-        expect(["127.0.0.1", "::1"]).toContain(response.data.remoteIP);
+        expect(localhosts).toContain(response.data.remoteIP);
 
         let count = 0;
         for (const id in api.connections.connections) {

--- a/src/config/web.ts
+++ b/src/config/web.ts
@@ -24,9 +24,9 @@ export const DEFAULT = {
         : [],
       // Port or Socket Path
       port: process.env.PORT || 8080,
-      // Which IP to listen on (use '0.0.0.0' for all; '::' for all on ipv4 and ipv6)
+      // Which IP to listen on (use '0.0.0.0' for the default ip stack; '::' for all on ipv4 and ipv6)
       // Set to `null` when listening to socket
-      bindIP: "0.0.0.0",
+      bindIP: "::",
       // Any additional headers you want actionhero to respond with
       httpHeaders: {
         "X-Powered-By": config.general.serverName,


### PR DESCRIPTION
In node.js v18, when binding to `0.0.0.0`, it will attach to either an ipv4 or ipv6 stack, depending on what the default is for your computer.  This can be confusing because binding the server to `0.0.0.0` on MacOS for instance, will repond to ipv6 requests (`http://::1:8080`) but not ipv4 (`http://localhost:8080`).

This PR changes the default behavior of the web server to bind to `::`, which should work for both ipv4 and ipv6.  