### PR TITLE
add removeMember to api.chatRoom

### DIFF
--- a/__tests__/core/cluster.ts
+++ b/__tests__/core/cluster.ts
@@ -101,6 +101,20 @@ describe("Core: Action Cluster", () => {
       expect(message.message).toEqual("hi");
     });
 
+    test("can call api.chatRoom.removeMember on other servers", async () => {
+      const client = await specHelper.buildConnection();
+      const spy = jest
+        .spyOn(api.chatRoom, "removeMember")
+        .mockImplementationOnce(jest.fn());
+      await redis.doCluster("api.chatRoom.removeMember", [
+        client.id,
+        "defaultRoom",
+      ]);
+      await utils.sleep(100);
+
+      expect(spy).toHaveBeenCalledWith(client.id, "defaultRoom");
+    });
+
     test("failing RPC calls with a callback will have a failure callback", async () => {
       try {
         await redis.doCluster(

--- a/src/initializers/chatRoom.ts
+++ b/src/initializers/chatRoom.ts
@@ -14,6 +14,7 @@ export interface ChatRoomApi {
   incomingMessage: ChatRoomInitializer["incomingMessage"];
   incomingMessagePerConnection?: ChatRoomInitializer["incomingMessagePerConnection"];
   runMiddleware: ChatRoomInitializer["runMiddleware"];
+  removeMember: ChatRoomInitializer["removeMember"];
 }
 
 export type ChatMiddlewareDirections =
@@ -160,6 +161,12 @@ export class ChatRoomInitializer extends Initializer {
     return newMessagePayload;
   };
 
+  removeMember = (
+    connectionId: string,
+    room: string,
+    toWaitRemote: boolean = true,
+  ) => chatRoom.removeMember(connectionId, room, toWaitRemote);
+
   async initialize() {
     api.chatRoom = {
       middleware: {},
@@ -174,6 +181,7 @@ export class ChatRoomInitializer extends Initializer {
       incomingMessage: this.incomingMessage,
       incomingMessagePerConnection: this.incomingMessagePerConnection,
       runMiddleware: this.runMiddleware,
+      removeMember: this.removeMember,
     };
   }
 


### PR DESCRIPTION
`removeMember` can be called as an RPC method [here](https://github.com/actionhero/actionhero/blob/main/src/modules/chatRoom.ts#L273). Since `removeMember` is not on the `api.chatRoom` object, it does not get executed and just logs `RPC method chatRoom.removeMember not found`.