### PR TITLE
Pass options to form contructor

### DIFF
--- a/src/actions/swagger.ts
+++ b/src/actions/swagger.ts
@@ -103,8 +103,8 @@ export class Swagger extends Action {
                     ? typeof action.inputs[inputName].default === "object"
                       ? JSON.stringify(action.inputs[inputName].default)
                       : typeof action.inputs[inputName].default === "function"
-                      ? action.inputs[inputName].default()
-                      : `${action.inputs[inputName].default}`
+                        ? action.inputs[inputName].default()
+                        : `${action.inputs[inputName].default}`
                     : undefined,
               };
             }),

--- a/src/config/web.ts
+++ b/src/config/web.ts
@@ -1,6 +1,8 @@
 import * as os from "os";
 import { ActionheroConfigInterface } from "..";
 
+import type { Options as FormParserOptions } from "formidable";
+
 const namespace = "web";
 
 declare module ".." {
@@ -83,7 +85,7 @@ export const DEFAULT = {
         keepExtensions: false,
         maxFieldsSize: 1024 * 1024 * 20,
         maxFileSize: 1024 * 1024 * 200,
-      },
+      } as FormParserOptions,
       // Should we pad JSON responses with whitespace to make them more human-readable?
       // set to null to disable
       padding: 2,

--- a/src/servers/web.ts
+++ b/src/servers/web.ts
@@ -693,7 +693,13 @@ export class WebServer extends Server {
         (connection.rawConnection.req.headers["content-type"] ||
           connection.rawConnection.req.headers["Content-Type"])
       ) {
-        connection.rawConnection.form = new formidable.IncomingForm(this.config.formOptions);
+        connection.rawConnection.form = new formidable.IncomingForm();
+        if (this.config?.formOptions) {
+          for (i in this.config.formOptions) {
+            connection.rawConnection.form.options[i] =
+              this.config.formOptions[i];
+          }
+        }
 
         let rawBody = Promise.resolve(Buffer.alloc(0));
         if (this.config.saveRawBody) {

--- a/src/servers/web.ts
+++ b/src/servers/web.ts
@@ -693,10 +693,7 @@ export class WebServer extends Server {
         (connection.rawConnection.req.headers["content-type"] ||
           connection.rawConnection.req.headers["Content-Type"])
       ) {
-        connection.rawConnection.form = new formidable.IncomingForm();
-        for (i in this.config.formOptions) {
-          connection.rawConnection.form.options[i] = this.config.formOptions[i];
-        }
+        connection.rawConnection.form = new formidable.IncomingForm(this.config.formOptions);
 
         let rawBody = Promise.resolve(Buffer.alloc(0));
         if (this.config.saveRawBody) {


### PR DESCRIPTION
As described [here](https://github.com/node-formidable/formidable#formidable--incomingform) options for IncomingForm should be passed to the contructor directly.