### PR TITLE
Allow custom content-type header for sending files

### DIFF
--- a/__tests__/integration/sendFile.ts
+++ b/__tests__/integration/sendFile.ts
@@ -21,4 +21,9 @@ describe("Server: sendFile", () => {
     expect(stats.size).toBeGreaterThanOrEqual(response.data.length);
     expect(response.data).toContain("PNG");
   });
+
+  test("Server should sendFile with custom content-type header", async () => {
+    const response = await axios.get(url + "/api/sendFile", { params: { contentType: "application/octet-stream" } });
+    expect(response.headers['content-type']).toBe("application/octet-stream");
+  });
 });

--- a/src/actions/sendFile.ts
+++ b/src/actions/sendFile.ts
@@ -4,8 +4,19 @@ export class SendFile extends Action {
   name = "sendFile";
   description = "I send a file though an action";
   outputExample = {};
+  inputs = {
+    contentType: {
+      required: false,
+      validator: (param: string) => {
+        return typeof param === "string";
+      }
+    }
+  };
 
-  async run(data: { connection: Connection; toRender: boolean }) {
+  async run(data: { params: { contentType: string }; connection: Connection; toRender: boolean }) {
+    if (data.params.contentType) {
+      data.connection.rawConnection.responseHeaders.push(['Content-Type', data.params.contentType])
+    }
     await data.connection.sendFile("logo/actionhero.png");
     data.toRender = false;
   }

--- a/src/servers/web.ts
+++ b/src/servers/web.ts
@@ -181,15 +181,23 @@ export class WebServer extends Server {
     lastModified: Date,
   ) {
     let foundCacheControl = false;
+    let foundContentType = false;
     let ifModifiedSince;
 
     connection.rawConnection.responseHeaders.forEach((pair: string[]) => {
-      if (pair[0].toLowerCase() === "cache-control") {
+      const headerName = pair[0].toLowerCase();
+      if (headerName === "cache-control") {
         foundCacheControl = true;
+      }
+      if (headerName === "content-type") {
+        foundContentType = true;
       }
     });
 
-    connection.rawConnection.responseHeaders.push(["Content-Type", mime]);
+    const hasDefaultJSONHeader = this.extractHeader(connection, 'Content-Type') === "application/json; charset=utf-8"
+    if (!foundContentType || hasDefaultJSONHeader) {
+      connection.rawConnection.responseHeaders.push(["Content-Type", mime]);
+    }
 
     if (fileStream) {
       if (!foundCacheControl) {


### PR DESCRIPTION
Makes it possible to configure the content-type header before sending a file. 

Use case:
- There is a file named `test.png_preview`
- Mimetype can not be inferred from file extension
- You want to specify the type yourself in the download action