### PR TITLE
Allow validators to have access to their param name

### DIFF
--- a/__tests__/actions/validationTest.ts
+++ b/__tests__/actions/validationTest.ts
@@ -28,6 +28,28 @@ describe("Action: validationTest", () => {
     );
   });
 
+  test("fails with generalized validation error message", async () => {
+    const { error } = await specHelper.runAction<ValidationTest>(
+      "validationTest",
+      {
+        string: "hello",
+        number: "invalid number",
+      },
+    );
+    expect(error).toEqual("Error: Param number is not a valid number!");
+  });
+
+  test("fails with generalized formatter error message", async () => {
+    const { error } = await specHelper.runAction<ValidationTest>(
+      "validationTest",
+      {
+        string: "hello",
+        number: 123,
+      },
+    );
+    expect(error).toEqual("Error: Failed formatting number correctly!");
+  });
+
   test("works with a string", async () => {
     const { string } = await specHelper.runAction<ValidationTest>(
       "validationTest",

--- a/src/actions/validationTest.ts
+++ b/src/actions/validationTest.ts
@@ -10,12 +10,27 @@ export class ValidationTest extends Action {
         return typeof param === "string";
       },
     },
+    number: {
+      required: false,
+      formatter: (param: string, name: string) => {
+        if (parseInt(param) == 123) {
+          throw new Error(`Failed formatting ${name} correctly!`);
+        }
+        return parseInt(param);
+      },
+      validator: (param: number, name: string) => {
+        if (typeof param === "number") {
+          throw new Error(`Param ${name} is not a valid number!`);
+        }
+      },
+    },
   };
   outputExample = {
     string: "imAString!",
+    number: 2,
   };
 
-  async run({ params }: { params: { string: string } }) {
-    return { string: params.string };
+  async run({ params }: { params: { string: string; number: number } }) {
+    return { string: params.string, number: params.number };
   }
 }

--- a/src/classes/actionProcessor.ts
+++ b/src/classes/actionProcessor.ts
@@ -305,10 +305,10 @@ export class ActionProcessor<ActionClass extends Action> {
         let validatorResponse;
         try {
           if (typeof validator === "function") {
-            validatorResponse = await validator.call(this, params[key]);
+            validatorResponse = await validator.call(this, params[key], key);
           } else {
             const method = this.prepareStringMethod(validator);
-            validatorResponse = await method.call(this, params[key]);
+            validatorResponse = await method.call(this, params[key], key);
           }
 
           // validator function returned nothing; assume param is OK

--- a/src/classes/actionProcessor.ts
+++ b/src/classes/actionProcessor.ts
@@ -286,10 +286,10 @@ export class ActionProcessor<ActionClass extends Action> {
       for (const i in props.formatter) {
         const formatter = props.formatter[i];
         if (typeof formatter === "function") {
-          params[key] = await formatter.call(this, params[key]);
+          params[key] = await formatter.call(this, params[key], key);
         } else {
           const method = this.prepareStringMethod(formatter);
-          params[key] = await method.call(this, params[key]);
+          params[key] = await method.call(this, params[key], key);
         }
       }
     }


### PR DESCRIPTION
## Issue
Currently, there is no way to use generic validators that include the name of the invalid parameter in the error message.

Expected functionality:
```ts
function validateXYZ(param: string, name: string) {
	if (...) {
		throw new Error(`Parameter ${name} is of type ${...} (expected ${...})`)
	}
} 
```

This PR allows for this by passing `key` as extra parameter. Also, it's backwards compatible as additional arguments are ignored.