### PR TITLE
Update formidable version and adjust for compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "commander": "^12.0.0",
         "dot-prop": "^6.0.1",
         "etag": "^1.8.1",
-        "formidable": "^2.1.2",
+        "formidable": "^3.5.1",
         "glob": "^8.1.0",
         "ioredis": "^5.3.2",
         "mime": "^3.0.0",
@@ -2862,14 +2862,13 @@
       }
     },
     "node_modules/formidable": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
-      "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.1.tgz",
+      "integrity": "sha512-WJWKelbRHN41m5dumb0/k8TeAx7Id/y3a+Z7QfhxP/htI9Js5zYaEDtG8uMgG0vM0lOlqnmjE99/kfpOYi/0Og==",
       "dependencies": {
         "dezalgo": "^1.0.4",
         "hexoid": "^1.0.0",
-        "once": "^1.4.0",
-        "qs": "^6.11.0"
+        "once": "^1.4.0"
       },
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
@@ -3463,9 +3462,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "commander": "^12.0.0",
     "dot-prop": "^6.0.1",
     "etag": "^1.8.1",
-    "formidable": "^2.1.2",
+    "formidable": "^3.5.1",
     "glob": "^8.1.0",
     "ioredis": "^5.3.2",
     "mime": "^3.0.0",


### PR DESCRIPTION
The "formidable" version is updated from 2.1.2 to 3.5.1. 

Corresponding changes have been made in the "web.ts" file to ensure backward compatibility between "formidable" version 3 and 2. Adjustments are made to deal with the removal of the `multiples` option and mechanism in "formidable" v3.

All tests passed.