### PR TITLE
Show `multiples` form options as optional argument to help users

### DIFF
--- a/__tests__/servers/web/enableMultiples.ts
+++ b/__tests__/servers/web/enableMultiples.ts
@@ -1,5 +1,4 @@
-import { PassThrough } from "stream";
-import axios, { AxiosError } from "axios";
+import axios from "axios";
 import { api, Process, config } from "./../../../src/index";
 import * as FormData from "form-data";
 

--- a/__tests__/servers/web/nonMultiples.ts
+++ b/__tests__/servers/web/nonMultiples.ts
@@ -1,5 +1,4 @@
-import { PassThrough } from "stream";
-import axios, { AxiosError } from "axios";
+import axios from "axios";
 import { api, Process, config } from "./../../../src/index";
 import * as FormData from "form-data";
 

--- a/src/config/web.ts
+++ b/src/config/web.ts
@@ -81,7 +81,7 @@ export const DEFAULT = {
       // Options to be applied to incoming file uploads.
       //  More options and details at https://github.com/felixge/node-formidable
       formOptions: {
-        multiples: true,
+        multiples: false, // enabling will allow for multiple values to be sent for a single key, e.g. array values, but will transform most POST/PUT payloads to arrays
         uploadDir: os.tmpdir(),
         keepExtensions: false,
         maxFieldsSize: 1024 * 1024 * 20,

--- a/src/config/web.ts
+++ b/src/config/web.ts
@@ -81,6 +81,7 @@ export const DEFAULT = {
       // Options to be applied to incoming file uploads.
       //  More options and details at https://github.com/felixge/node-formidable
       formOptions: {
+        multiples: true,
         uploadDir: os.tmpdir(),
         keepExtensions: false,
         maxFieldsSize: 1024 * 1024 * 20,


### PR DESCRIPTION
re: https://github.com/actionhero/actionhero/issues/2834

We already have some tests for this case in https://github.com/actionhero/actionhero/blob/main/__tests__/servers/web/enableMultiples.ts

UPDATE: Enabling this by default would be a breaking change, as most arguments in POST/PUT would become arrays.  So, instead, we'll show that the option exists and explain what it does.